### PR TITLE
Use the full '2.0.0' version instead of '2.0'

### DIFF
--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -29,7 +29,7 @@ The following table lists the configurable parameters and their default values.
 |             Parameter       |            Description             |                    Default                |
 |-----------------------------|------------------------------------|-------------------------------------------|
 | `image.name`                | The image name       to pull from  | `purestorage/k8s`                 |
-| `image.tag`                 | The image tag to pull              | `latest`                                  |
+| `image.tag`                 | The image tag to pull              | `2.0.0`                                  |
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
 | `app.debug`                 | Enable/disable debug mode for app  | `false`                                  |
 | `storageclass.isPureDefault`| Set `pure` storageclass to the default | `false`       |

--- a/pure-k8s-plugin/values.yaml
+++ b/pure-k8s-plugin/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   name: purestorage/k8s
-  tag: 2.0
+  tag: 2.0.0
   pullPolicy: IfNotPresent
 
 # this option is to enable/disable the debug mode of this app


### PR DESCRIPTION
This is both more correct, and will actually be treated as a string
correctly when parsed.