### PR TITLE
Adding a selector to avoid matching on all labels.

### DIFF
--- a/pure-k8s-plugin/templates/pure-flex-daemon.yaml
+++ b/pure-k8s-plugin/templates/pure-flex-daemon.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
 {{ include "pure_k8s_plugin.labels" . | indent 4}}
 spec:
+  selector:
+    matchLabels:
+      app: pure-flex
   template:
     metadata:
       labels:

--- a/pure-k8s-plugin/templates/pure-provisioner.yaml
+++ b/pure-k8s-plugin/templates/pure-provisioner.yaml
@@ -7,6 +7,9 @@ metadata:
 {{ include "pure_k8s_plugin.labels" . | indent 4}}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: pure-provisioner
   template:
     metadata:
       labels:


### PR DESCRIPTION
From what I can tell this does not help if the old helm chart did not have the selector. Moving forward however we should be able to update even if labels change.