### PR TITLE
NSTK-1162 : Add a new ClusterRole + ClusterRoleBinding to the provisioner

### DIFF
--- a/pure-k8s-plugin/templates/clusterrolebinding.yaml
+++ b/pure-k8s-plugin/templates/clusterrolebinding.yaml
@@ -7,6 +7,51 @@ metadata:
 
 ---
 
+# Add event list cluster role
+{{- if (eq "k8s" .Values.orchestrator.name) }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else }}
+apiVersion: authorization.openshift.io/v1
+{{- end}}
+kind: ClusterRole
+metadata:
+  name: pure-provisioner-list-events
+  labels:
+{{ include "pure_k8s_plugin.labels" . | indent 4}}
+rules:
+- apiGroups:
+- ""
+resources:
+- events
+verbs:
+- list
+
+---
+
+# Assign pure-provisioner-list-events cluster role to the service account
+{{- if (eq "k8s" .Values.orchestrator.name) }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else }}
+apiVersion: authorization.openshift.io/v1
+{{- end}}
+kind: ClusterRoleBinding
+metadata:
+  name: pure-provisioner-event-list-rights
+  labels:
+{{ include "pure_k8s_plugin.labels" . | indent 4}}
+roleRef:
+{{- if (eq "k8s" .Values.orchestrator.name) }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- end }}
+  name: pure-provisioner-list-events
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.clusterrolebinding.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+
+---
+
 # Assign cluster role to the service account
 {{- if (eq "k8s" .Values.orchestrator.name) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION

This is a requirement of the newer external-storage/lib provisioner interface.
Without this change provisioner is forbidden to list events and cannot provision volumes.

Description of problem from the JIRA:
At some point we will update the k8s/vendor to use the latest version of k8s i.e. 1.13 as flexvolume resize is only in 1.13

Whenever this happens out vendor/...external-stroage/lib files will be unhapy because it imports "k8s.io/client-go/pkg/api/v1" which was moved to 
"k8s.io/api/core/v1" 
As a result we will need to upgrade external-storage/ to v4.0.0 from existing v2.1.0 
Now the pain part: somewhere along the way external-storage/controller added List-events to the RBAC needed by the provisioner.
 But according to : https://github.com/kubernetes/kubernetes/blob/4e01d1d1412950250148d25ca607fb9585f4c86b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L693 "list events" is not in the RBAC for system:persistent-volume-provisioner 

 


