### PR TITLE
Add option to set  storageclass backend type

### DIFF
--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -33,6 +33,7 @@ The following table lists the configurable parameters and their default values.
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
 | `app.debug`                 | Enable/disable debug mode for app  | `false`                                   |
 | `storageclass.isPureDefault`| Set `pure` storageclass to the default | `false`                               |
+| `storageclass.pureBackend`  | Set `pure` storageclass' default backend type | `block`                               |
 | `clusterrolebinding.serviceAccount.name`| Name of K8s/openshift service account for installing the plugin | `pure`                    |
 | `flasharray.sanType`        | Block volume access protocol, either ISCSI or FC | `ISCSI`                     |
 | `flasharray.defaultFSType`  | Block volume default filesystem type. *Not recommended to change!* | `xfs`     |

--- a/pure-k8s-plugin/templates/storageclass.yaml
+++ b/pure-k8s-plugin/templates/storageclass.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ include "pure_k8s_plugin.labels" . | indent 4}}
 provisioner: pure-provisioner
 parameters:
-    backend: block
+    backend: {{ default "block" .Values.storageclass.pureBackend }}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/pure-k8s-plugin/templates/storageclass.yaml
+++ b/pure-k8s-plugin/templates/storageclass.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ include "pure_k8s_plugin.labels" . | indent 4}}
 provisioner: pure-provisioner
 parameters:
-    backend: {{ default "block" .Values.storageclass.pureBackend }}
+    backend: {{ .Values.storageclass.pureBackend | default "block" | quote }}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1

--- a/pure-k8s-plugin/values.yaml
+++ b/pure-k8s-plugin/values.yaml
@@ -15,6 +15,8 @@ app:
 # do you want to set pure as the default storageclass?
 storageclass:
   isPureDefault: false
+  # set the type of backend you want for the 'pure' storageclass
+  # pureBackend: file
 
 # specify the service account name for this app
 clusterrolebinding:


### PR DESCRIPTION
In addition to setting `pure` storageclass as default storageclass we desired the ability to choose which type of backend the default was. These changes allow you to set the default backend type of `block` or `file`

An example would be to edit the `values.yaml` from:
```
# do you want to set pure as the default storageclass?
storageclass:
  isPureDefault: false
```
to: 
```
# do you want to set pure as the default storageclass?
storageclass:
  isPureDefault: false
  pureBackend: file
```