### PR TITLE
pass default filesystem type to pure-provisioner

### DIFF
--- a/pure-k8s-plugin/templates/pure-provisioner.yaml
+++ b/pure-k8s-plugin/templates/pure-provisioner.yaml
@@ -36,6 +36,8 @@ spec:
             value: /etc/pure/pure.json
           - name: PURE_K8S_NAMESPACE
             value: {{ .Values.namespace.pure }}
+          - name: PURE_DEFAULT_BLOCK_FS_TYPE
+            value: {{ .Values.flasharray.defaultFSType }}
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
Pass the filesystem type to pure-provisioner. So that, provisioner will label the PV with correct flex driver and filesystem type.