### PR TITLE
Update orchestrator.openshift.flexPath parameter

### DIFF
--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -45,7 +45,7 @@ The following table lists the configurable parameters and their default values.
 | `orchestrator.k8s.flexBaseDir` | Base path of directory to install flex plugin, works with orchestrator.name=k8s and image.tag < 2.0. Sub-dir of "volume/exec/pure~flex" will be automatically created under it | `/usr/libexec/kubernetes/kubelet-plugins` |
 | `orchestrator.k8s.flexPath` | Full path of directory to install flex plugin, works with orchestrator.name=k8s and image.tag >= 2.0.1 | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec` |
 | `orchestrator.openshift.flexBaseDir` | Base path of directory to install flex plugin, works with orchestrator.name=openshift and image.tag < 2.0. Sub-dir of "volume/exec/pure~flex" will be automatically created under it | `/etc/origin/node/kubelet-plugins` |
-| `orchestrator.openshift.flexPath` | Full path of directory to install flex plugin, works with orchestrator.name=k8s and image.tag >= 2.0.1 | `/etc/origin/node/kubelet-plugins/volume/exec` |
+| `orchestrator.openshift.flexPath` | Full path of directory to install flex plugin, works with orchestrator.name=k8s and image.tag >= 2.0.1 | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec` |
 | *`arrays`                    | Array list of all the backend FlashArrays and FlashBlades | must be set by user, see an example below                |
 
 *Examples:

--- a/pure-k8s-plugin/values.yaml
+++ b/pure-k8s-plugin/values.yaml
@@ -46,7 +46,7 @@ orchestrator:
     # flexBaseDir is for image.tag < 2.0
     flexBaseDir: /etc/origin/node/kubelet-plugins
     # flexPath is for image.tag >= 2.0
-    flexPath: /etc/origin/node/kubelet-plugins/volume/exec
+    flexPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
   k8s:
     flexBaseDir: /usr/libexec/kubernetes/kubelet-plugins
     flexPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec


### PR DESCRIPTION
Point to the correct directory that has been used in OpenShift since 3.9. This now matches upstream kubernetes.

This is the major cause of customer issues - ie. not having this directory value correct, even though the README does say to check...