### PR TITLE
Dinathom/nodeselect

### DIFF
--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters and their default values.
 | `orchestrator.name`         | Orchestrator type, such as openshift, k8s | `k8s`                              |
 | `flexPath`                  | Full path of directory to install flex plugin, works with image.tag >= 2.0.1 | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec` |
 | *`arrays`                    | Array list of all the backend FlashArrays and FlashBlades | must be set by user, see an example below                |
-| `nodeSelector`              | [NodeSelectors](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) | `{}` |
+| `nodeSelector`              | [NodeSelectors](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) Select node-labels to schedule flex-plugin. See [this](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#using-node-selectors) for setting node selectors on Openshift. | `{}` |
 | `tolerations`               | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts)  | `[]` |
 | `affinity`                  | [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) | `{}` |
 

--- a/pure-k8s-plugin/templates/pure-flex-daemon.yaml
+++ b/pure-k8s-plugin/templates/pure-flex-daemon.yaml
@@ -17,10 +17,6 @@ spec:
         app: pure-flex
 {{ include "pure_k8s_plugin.labels" . | indent 8}}
     spec:
-{{- if (eq "openshift" .Values.orchestrator.name) }}
-      nodeSelector:
-        node-role.kubernetes.io/compute: "true"
-{{- end}}
       serviceAccountName: {{ .Values.clusterrolebinding.serviceAccount.name }}
       containers:
         - name: pure-flex

--- a/pure-k8s-plugin/values.yaml
+++ b/pure-k8s-plugin/values.yaml
@@ -53,7 +53,7 @@ orchestrator:
 flexPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
 
 # Default for Openshift 3.10+ on RHEL Atomic (containerized kubelet/origin-node)
-#flexPath: /etc/origin/kubelet-plugins/volume/exec
+#flexPath: /etc/origin/node/kubelet-plugins/volume/exec
 
 # Default for Openshift 3.9 and lower with RHEL Atomic
 #flexPath : /usr/libexec/kubernetes/kubelet-plugins/volume/exec


### PR DESCRIPTION
Remove hard-coded nodeSelector from pure-flex template. 
By default our pure-flex will not have a nodeSelector specified which means we will default to using whatever is in the project-wide nodeSelector. If project-wide node selector is not specified it will use the cluster-wide node selector. See https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#using-node-selectors
