### PR TITLE
Adding additionalStorageClasses option

### DIFF
--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -32,8 +32,10 @@ The following table lists the configurable parameters and their default values.
 | `image.tag`                 | The image tag to pull              | `2.2.1`                                   |
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
 | `app.debug`                 | Enable/disable debug mode for app  | `false`                                   |
+| `storageclass.create`       | Create default storage classes     | `true`                                    |
 | `storageclass.isPureDefault`| Set `pure` storageclass to the default | `false`                               |
-| `storageclass.pureBackend`  | Set `pure` storageclass' default backend type | `block`                               |
+| `storageclass.pureBackend`  | Set `pure` storageclass' default backend type | `block`                        |
+| `additionalStorageClasses`  | Configure additional StorageClasses | see example in values.yaml               |
 | `clusterrolebinding.serviceAccount.name`| Name of K8s/openshift service account for installing the plugin | `pure`                    |
 | `flasharray.sanType`        | Block volume access protocol, either ISCSI or FC | `ISCSI`                     |
 | `flasharray.defaultFSType`  | Block volume default filesystem type. *Not recommended to change!* | `xfs`     |

--- a/pure-k8s-plugin/templates/storageclass.yaml
+++ b/pure-k8s-plugin/templates/storageclass.yaml
@@ -1,5 +1,6 @@
-apiVersion: storage.k8s.io/v1
+{{- if .Values.storageclass.create -}}
 kind: StorageClass
+apiVersion: storage.k8s.io/v1
 metadata:
   name: pure
   annotations:
@@ -32,3 +33,26 @@ metadata:
 provisioner: pure-provisioner
 parameters:
     backend: block
+{{- end }}
+{{- $lables := include "pure_k8s_plugin.labels" . -}}
+{{- range .Values.additionalStorageClasses }}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .name }}
+{{- if .annotations }}
+  annotations:
+{{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+  labels:
+{{- range $key, $value := .labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{ $lables | indent 4 }}
+provisioner: pure-provisioner
+parameters:
+    backend: {{ .backend | default "block" }}
+{{- end }}

--- a/pure-k8s-plugin/values.yaml
+++ b/pure-k8s-plugin/values.yaml
@@ -14,9 +14,26 @@ app:
 
 # do you want to set pure as the default storageclass?
 storageclass:
+  create: false
   isPureDefault: false
   # set the type of backend you want for the 'pure' storageclass
   # pureBackend: file
+
+additionalStorageClasses:
+#- name: pure
+#  annotations:
+#    storageclass.beta.kubernetes.io/is-default-class: "false"
+#  labels:
+#    kubernetes.io/cluster-service: "true"
+#  backend: block
+#- name: pure-file
+#  labels:
+#    kubernetes.io/cluster-service: "true"
+#  backend: file
+#- name: pure-block
+#  labels:
+#    kubernetes.io/cluster-service: "true"
+#  backend: block
 
 # specify the service account name for this app
 clusterrolebinding:


### PR DESCRIPTION
Adding the additionalStorageClasses option that @patrick-east suggested in https://github.com/purestorage/helm-charts/pull/71.  Three example classes have been added to the values.yaml that will produce three StorageClasses identical to the three default ones.

A storageclass.create option has also been added that allows uses to turn off the creation of the default three StorageClasses. The default value is true to maintain backwards compatibility.


