### PR TITLE
Fixes to flexPath  and SCC for Openshift

### DIFF
--- a/operator/install.sh
+++ b/operator/install.sh
@@ -87,7 +87,7 @@ supplementalGroups:
 
     # Grant this SCC to the service account creating the flex-daemonset
     # extract the clusterrolebinding.serviceAccount.name from the values.yaml file if it exists.
-    SVC_ACCNT=$(awk '/clusterrolebinding:/,/name:/' ${VALUESFILE} | grep 'name:' | sed  's/^.*://; s/#.*$//; s/ *$//; /^$/d;')
+    SVC_ACCNT=$(awk '/clusterrolebinding:/,0' ${VALUESFILE} | grep 'name:' | sed  ' s/#.*$//; s/^.*://; s/ *$//; /^$/d;' | head -1)
     if [[ -z ${SVC_ACCNT} ]]; then
         SVC_ACCNT=pure
     fi

--- a/operator/install.sh
+++ b/operator/install.sh
@@ -65,6 +65,33 @@ if [[ "${KUBECTL}" == "kubectl" ]]; then
     $KUBECTL create namespace ${NAMESPACE}
 else
     $KUBECTL adm new-project ${NAMESPACE} 
+    
+    # Since this plugin needs to mount external volumes to containers, create a SCC to allow the flex-daemon pod to
+    # use the hostPath volume plugin
+echo '
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: hostpath
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+' | $KUBECTL create -f -
+
+    # Grant this SCC to the service account creating the flex-daemonset
+    # extract the clusterrolebinding.serviceAccount.name from the values.yaml file if it exists.
+    SVC_ACCNT=$(awk '/clusterrolebinding:/,/name:/' ${VALUESFILE} | grep 'name:' | sed  's/^.*://; s/#.*$//; s/ *$//; /^$/d;')
+    if [[ -z ${SVC_ACCNT} ]]; then
+        SVC_ACCNT=pure
+    fi
+    $KUBECTL adm policy add-scc-to-user hostpath -n ${NAMESPACE} -z ${SVC_ACCNT} 
 fi
 
 # 2. Create CRD and wait until TIMEOUT seconds for the CRD to be established.

--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -274,15 +274,7 @@ path to use is something like `/etc/origin/kubelet-plugins` or similar
 as the node config path is passed through to the container.
 
 # Release Notes
-
-## pure-k8s-plugin 2.4.0
-### Changes
-- [PSO Operator](../operator/README.md#pso-operator) is now  the preferred install method for PSO on OpenShift 3.11 and higher versions. 
-The PSO Operator packages and deploys the Pure Service Orchestrator (PSO) on OpenShift for dynamic provisioning of persistent volumes on FlashArrays and FlashBlades. The minimum supported version is OpenShift 3.11.
-This Operator is created as a [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) from the [pure-k8s-plugin Helm chart](https://github.com/purestorage/helm-charts#purestorage-helm-charts-and-helm-operator) using the [Operator-SDK](https://github.com/operator-framework/operator-sdk#overview).
-This installation process does not require Helm installation. 
-- Added flasharray.iSCSILoginTimeout parameter with default value of 20sec.
-- Added flasharray.iSCSIAllowedCIDR parameter to list CIDR blocks allowed as iSCSI targets. The default value allows all addresses.
+Release notes can be found [here](https://github.com/purestorage/helm-charts/releases)
 
 ### Known Vulnerabilities 
 - [CVE-2019-1543](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1543)

--- a/pure-k8s-plugin/templates/_helpers.tpl
+++ b/pure-k8s-plugin/templates/_helpers.tpl
@@ -9,5 +9,8 @@ release: {{ .Release.Name | quote }}
 {{/* Define the flexpath to install pureflex
 */}}
 {{ define "pure_k8s_plugin.flexpath" -}}
-{{ .Values.flexPath }}
+{{ if eq .Values.orchestrator.name "k8s" -}}
+{{ .Values.flexPath | .Values.orchestrator.k8s.flexPath }}
+{{ else if eq .Values.orchestrator.name "openshift" -}}
+{{ .Values.flexPath | .Values.orchestrator.openshift.flexPath }}
 {{- end -}}


### PR DESCRIPTION
The current operator install assumes privileged SCC has been granted to the service account for pure-flex and pure-provisioner.
However that is overkill and we just need a hostPath SCC created and grant that SCC to the service account. 


This PR also fixes the flexPath compatibility issue with pre-2.2.1 release.