### PR TITLE
Adding a ClusterRole and Role.

### DIFF
--- a/pure-k8s-plugin/templates/clusterrolebinding.yaml
+++ b/pure-k8s-plugin/templates/clusterrolebinding.yaml
@@ -7,23 +7,72 @@ metadata:
 
 ---
 
-# Assign cluster role to the service account
-{{- if (eq "k8s" .Values.orchestrator.name) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- else }}
-apiVersion: authorization.openshift.io/v1
-{{- end}}
+kind: ClusterRole
+metadata:
+  labels:
+{{ include "pure_k8s_plugin.labels" . | indent 4}}
+  name: pure-provisioner-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["create", "delete", "get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "update", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch", "update", "watch"]
+
+---
+
+# Assign cluster role to the service account
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: pure-provisioner-rights
   labels:
 {{ include "pure_k8s_plugin.labels" . | indent 4}}
 roleRef:
-{{- if (eq "k8s" .Values.orchestrator.name) }}
-  apiGroup: rbac.authorization.k8s.io
+  apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRole
-{{- end }}
-  name: system:persistent-volume-provisioner
+  name: pure-provisioner-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.clusterrolebinding.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: pure-provisioner-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "pure_k8s_plugin.labels" . | indent 4}}
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+
+---
+
+# Assign role to the service account
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: pure-provisioner-rights-ns
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "pure_k8s_plugin.labels" . | indent 4}}
+roleRef:
+  apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: Role
+  name: pure-provisioner-role
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.clusterrolebinding.serviceAccount.name }}


### PR DESCRIPTION
This is needed as part of a controller library upgrade.
- We need "patch" permission on persistent volumes.
- We also need endpoint permissions in plugin's namespace.