### PR TITLE
The roleRef needs an "apiGroup" not "apiVersion".

### DIFF
--- a/pure-k8s-plugin/templates/clusterrolebinding.yaml
+++ b/pure-k8s-plugin/templates/clusterrolebinding.yaml
@@ -37,7 +37,7 @@ metadata:
   labels:
 {{ include "pure_k8s_plugin.labels" . | indent 4}}
 roleRef:
-  apiVersion: rbac.authorization.k8s.io/v1beta1
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: pure-provisioner-clusterrole
 subjects:
@@ -70,7 +70,7 @@ metadata:
   labels:
 {{ include "pure_k8s_plugin.labels" . | indent 4}}
 roleRef:
-  apiVersion: rbac.authorization.k8s.io/v1beta1
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: pure-provisioner-role
 subjects:


### PR DESCRIPTION
This doesn't seem to fail during application of the yaml but newer helm versions validate this.