### PR TITLE
Fix PSO Operator update issue 

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -47,8 +47,7 @@ The PSO Operator needs the following Cluster-level Roles and RoleBindings.
 | ------------- |:-------------:| -----:|
 | Namespace | Get | PSO Operator needs the ability to get created namespaces |
 | Storageclass | Create/Delete | Create and cleanup storage classes to be used for Provisioning |
-| ClusterRoleBinding | Create/Delete | PSO Operator needs to create and cleanup a ClusterRoleBinding called ``pure-provisioner-rights`` to the ClusterRole ``system:persistent-volume-provisioner`` for provisioning PVs |
-| ClusterRoleBinding | Get permission on ResourceName ``pure-provisioner-rights`` | PSO-operator needs the ability to get the ClusterRoleBinding it has created for provisioning. |
+| ClusterRoleBinding | Create/Delete/Get | PSO Operator needs to create and cleanup a ClusterRoleBinding called ``pure-provisioner-rights`` to the ClusterRole ``system:persistent-volume-provisioner`` for provisioning PVs |
 <br/>
 In addition, the operator needs access to multiple resources in the project/namespace that it is deployed in to function correctly. Hence it is recommended to install the PSO-operator in the non-default namespace.
 <br/>

--- a/operator/install.sh
+++ b/operator/install.sh
@@ -170,15 +170,6 @@ rules:
     verbs:
     - "create"
     - "delete"
-  - apiGroups:
-    - rbac.authorization.k8s.io
-    resources:
-    - clusterrolebindings
-    - clusterroles
-    resourceNames:
-    - "pure-provisioner-rights"
-    - "pure-provisioner-clusterrole"
-    verbs:
     - "get"
 # On Openshift ClusterRoleBindings belong to a different apiGroup.
   - apiGroups:
@@ -189,17 +180,6 @@ rules:
     verbs:
     - "create"
     - "delete"
-# PSO creates the "pure-provisioner-clusterrole" and "pure-provisioner-rights" and should be able
-# to get this by resource name
-  - apiGroups:
-    - authorization.openshift.io
-    resources:
-    - clusterrolebindings
-    - clusterroles
-    resourceNames:
-    - "pure-provisioner-rights"
-    - "pure-provisioner-clusterrole"
-    verbs:
     - "get"
 # Need the same permissions as pure-provisioner-clusterrole to be able to create it
   - apiGroups:


### PR DESCRIPTION
PSO Operator updates is broken as of Release 2.5.0+
This is because the chart now creates a ClusteRole "pure-provisioner-clusterrole" and we cannot Get the ClusterRole resource by name before it is created.
Earlier we used the system:persistent-volume-provisioner ClusterRole which already exists. Hence it was okay to add "get" privilege to the Clusterrole by resource name.
Because of this issue updates fail i.e. Operator does not apply changes in values.yaml.
The fix is to add "get" privilege to ClusterRole without using the resource-name qualifier.