### PR TITLE
Fix some doc errors and some logic in the Operator install scripts and add missing file

### DIFF
--- a/operator-csi-plugin/README.md
+++ b/operator-csi-plugin/README.md
@@ -26,7 +26,7 @@ This installation process does not require Helm installation.
 
 _* Please see release notes for details_
 
-## Additional configuration for Kuberenetes 1.13
+## Additional configuration for Kubernetes 1.13 Only
 For details see the [CSI documentation](https://kubernetes-csi.github.io/docs/csi-driver-object.html). 
 In Kubernetes 1.12 and 1.13 CSI was alpha and is disabled by default. To enable the use of a CSI driver on these versions, do the following:
 
@@ -38,8 +38,11 @@ $> kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/master
 
 ## Installation
 
-Clone this GitHub repository, selecting the version of the operator you wish to install. We recommend using the latest released version.</br>
-```git clone --branch <version> https://github.com/purestorage/helm-charts.git```
+Clone this GitHub repository, selecting the version of the operator you wish to install. We recommend using the latest released version. Information on this can be found [here](https://github.com/purestorage/helm-charts/releases)</br>
+```
+git clone --branch <version> https://github.com/purestorage/helm-charts.git
+cd operator-csi-plugin
+```
 
 Create your own `values.yaml`. The easiest way is to copy the default [./values.yaml](./values.yaml) with `wget`.
 
@@ -50,7 +53,7 @@ Parameter list:<br/>
 1. ``image`` is the Pure CSI Operator image. If unspecified ``image`` resolves to the released version at [quay.io/purestorage/pso-operator](https://quay.io/purestorage/pso-operator).
 2. ``namespace`` is the namespace/project in which the Pure CSI Operator and its entities will be installed. If unspecified, the operator creates and installs in  the ``pure-csi-operator`` namespace.
 **Pure CSI Operator MUST be installed in a new project with no other pods. Otherwise an uninstall may delete pods that are not related to the Pure CSI Operator.**
-3. ``orchestrator`` defaults to ``k8s`` 
+3. ``orchestrator`` defaults to ``k8s``. Options are ``k8s`` or ``openshift``. 
 4. ``values.yaml`` is the customized helm-chart configuration parameters. This is a **required parameter** and must contain the list of all backend FlashArray and FlashBlade storage appliances. All parameters that need a non-default value must be specified in this file. 
 Refer to [Configuration for values.yaml.](../pure-csi/README.md#configuration)
 
@@ -98,6 +101,20 @@ The ``update.sh`` script is used to apply changes from ``values.yaml`` as follow
 ## Uninstall
 To uninstall the Pure CSI Operator, run 
 ```
-oc delete all --all -n <pure-csi-operator-installed-namespace>
+kubectl delete all --all -n <pure-csi-operator-installed-namespace>
 ```
 where ``pure-csi-operator-installed-namespace`` is the project/namespace in which the Pure CSI Operator is installed. It is **strongly recommended** to install the Pure CSI Operator in a new project and not add any other pods to this project/namespace. Any pods in this project will be cleaned up on an uninstall. 
+
+If you are using OpenShift, replace `kubectl` with `oc`.
+To completely remove the CustomResourceDefinition used by the Operator run
+```
+kubectl delete crd psoplugins.purestorage.com
+```
+If the CRD fails to delete you may be experiencing a known issue. Resolve this by running:
+```
+kubectl patch crd/psoplugins.purestorage.com -p '{"metadata":{"finalizers":[]}}' --type=merge
+```
+If you are using OpenShift, replace `kubectl` with `oc` in the above commands.
+
+# License
+https://www.purestorage.com/content/dam/purestorage/pdf/legal/pure-plugin-end-user-license-agmt-sept-18-2017.pdf

--- a/operator-csi-plugin/install.sh
+++ b/operator-csi-plugin/install.sh
@@ -2,15 +2,16 @@
 IMAGE=quay.io/purestorage/pso-operator:v5.0.0
 NAMESPACE=pure-csi-operator
 KUBECTL=kubectl
+ORCHESTRATOR=k8s
 
 usage()
 {
     echo "Usage : $0 --image=<imagename> --namespace=<namespace> --orchestrator=<orchestrator> -f <values.yaml>"
-    exit
 }
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     usage
+    exit
 fi
 
 while (("$#")); do
@@ -53,8 +54,8 @@ case "$1" in
 done
 
 if [[ -z ${VALUESFILE} || ! -f ${VALUESFILE} ]]; then
+    echo "File ${VALUESFILE} does not exist"
     usage
-    echo "File ${VALUESFILE} for values.yaml does not exist"
     exit 1
 fi
 

--- a/operator-csi-plugin/values.yaml
+++ b/operator-csi-plugin/values.yaml
@@ -1,0 +1,112 @@
+# Default values for csi-plugin.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  name: purestorage/k8s
+  tag: 5.0.0
+  pullPolicy: IfNotPresent
+
+# this option is to enable/disable the debug mode of this app
+# for pure-csi-driver
+app:
+  debug: false
+
+# do you want to set pure as the default storageclass?
+storageclass:
+  isPureDefault: false
+  # set the type of backend you want for the 'pure' storageclass
+  # pureBackend: file
+
+# specify the service account name for this app
+clusterrolebinding:
+  serviceAccount:
+    name: pure
+
+# support ISCSI or FC, not case sensitive
+flasharray:
+  sanType: ISCSI
+  defaultFSType: xfs
+  defaultFSOpt: "-q"
+  defaultMountOpt: ""
+  preemptAttachments: "true"
+  iSCSILoginTimeout: 20
+
+flashblade:
+  snapshotDirectoryEnabled: "false"
+
+# there are two namespaces for this app
+# 1. namespace.pure is the backend storage namespace where volumes/shares/etc
+#    will be created.
+namespace:
+  pure: k8s
+
+# support k8s or openshift
+orchestrator:
+  # name is either 'k8s' or 'openshift'
+  name: k8s
+
+# arrays specify what storage arrays should be managed by the plugin, this is
+# required to be set upon installation. For FlashArrays you must set the "MgmtEndPoint"
+# and "APIToken", and for FlashBlades you need the additional "NfsEndPoint" parameter.
+# The labels are optional, and can be any key-value pair for use with the "fleet"
+# provisioner. An example is shown below:
+arrays:
+  #FlashArrays:
+  #  - MgmtEndPoint: "1.2.3.4"
+  #    APIToken: "a526a4c6-18b0-a8c9-1afa-3499293574bb"
+  #    Labels:
+  #      rack: "22"
+  #      env: "prod"
+  #  - MgmtEndPoint: "1.2.3.5"
+  #    APIToken: "b526a4c6-18b0-a8c9-1afa-3499293574bb"
+  #FlashBlades:
+  #  - MgmtEndPoint: "1.2.3.6"
+  #    APIToken: "T-c4925090-c9bf-4033-8537-d24ee5669135"
+  #    NfsEndPoint: "1.2.3.7"
+  #    Labels:
+  #      rack: "7b"
+  #      env: "dev"
+  #  - MgmtEndPoint: "1.2.3.8"
+  #    APIToken: "T-d4925090-c9bf-4033-8537-d24ee5669135"
+  #    NfsEndPoint: "1.2.3.9"
+  #    Labels:
+  #      rack: "6a"
+
+mounter:
+  # These values map directly to yaml in the daemonset spec, see the kubernetes docs for info
+  nodeSelector: {}
+    # disktype: ssd
+  # These values map directly to yaml in the daemonset spec, see the kubernetes docs for info
+  tolerations: []
+    # - operator: Exists
+  # These values map directly to yaml in the daemonset spec, see the kubernetes docs for info
+  affinity: {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: e2e-az-NorthSouth
+    #         operator: In
+    #         values:
+    #         - e2e-az-North
+    #         - e2e-az-South
+
+provisioner:
+  # These values map directly to yaml in the deployment spec, see the kubernetes docs for info
+  nodeSelector: {}
+    # disktype: ssd
+  # These values map directly to yaml in the deployment spec, see the kubernetes docs for info
+  tolerations: []
+    # - operator: Exists
+  # These values map directly to yaml in the deployment spec, see the kubernetes docs for info
+  affinity: {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: e2e-az-NorthSouth
+    #         operator: In
+    #         values:
+    #         - e2e-az-North
+    #         - e2e-az-South

--- a/operator-k8s-plugin/README.md
+++ b/operator-k8s-plugin/README.md
@@ -32,7 +32,10 @@ _* Please see release notes for details_
 ## Installation
 
 Clone this GitHub repository, selecting the version of the operator you wish to install. We recommend using the latest released version.</br>
-```git clone --branch <version> https://github.com/purestorage/helm-charts.git```
+```
+git clone --branch <version> https://github.com/purestorage/helm-charts.git
+cd operator-k8s-plugin
+```
 
 Create your own `values.yaml`. The easiest way is to copy the default [./values.yaml](./values.yaml) with `wget`.
 
@@ -43,7 +46,7 @@ Parameter list:<br/>
 1. ``image`` is the Pure Flex Operator image. If unspecified ``image`` resolves to the released version at [quay.io/purestorage/pso-operator](https://quay.io/purestorage/pso-operator).
 2. ``namespace`` is the namespace/project in which the Pure Flex Operator and its entities will be installed. If unspecified, the operator creates and installs in  the ``pso-operator`` namespace.
 **Pure Flex Operator MUST be installed in a new project with no other pods. Otherwise an uninstall may delete pods that are not related to the Pure Flex operator.**
-3. ``orchestrator`` should be either ``k8s`` or ``openshift`` depending on which orchestrator is being used. If unspecified, ``openshift`` is assumed.
+3. ``orchestrator`` should be either ``k8s`` or ``openshift`` depending on which orchestrator is being used. If unspecified, ``k8s`` is assumed.
 4. ``values.yaml`` is the customized helm-chart configuration parameters. This is a **required parameter** and must contain the list of all backend FlashArray and FlashBlade storage appliances. All parameters that need a non-default value must be specified in this file. 
 Refer to [Configuration for values.yaml.](../pure-k8s-plugin/README.md#configuration)
 
@@ -94,8 +97,22 @@ The ``update.sh`` script is used to apply changes from ``values.yaml`` as follow
 ```
 
 ## Uninstall
-To uninstall the Pure Flex Operator, run 
+To uninstall the Pure CSI Operator, run
 ```
-oc delete all --all -n <pso-operator-installed-namespace>
+kubectl delete all --all -n <pure-csi-operator-installed-namespace>
 ```
-where ``pso-operator-installed-namespace`` is the project/namespace in which the Pure Flex operator is installed. It is **strongly recommended** to install the Pure Flex Operator in a new project and not add any other pods to this project/namespace. Any pods in this project will be cleaned up on an uninstall. 
+where ``pure-csi-operator-installed-namespace`` is the project/namespace in which the Pure CSI Operator is installed. It is **strongly recommended** to install the Pure CSI Operator in a new project and not add any other pods to this project/namespace. Any pods in this project will be cleaned up on an uninstall.
+
+If you are using OpenShift, replace `kubectl` with `oc`.
+To completely remove the CustomResourceDefinition used by the Operator run
+```
+kubectl delete crd psoplugins.purestorage.com
+```
+If the CRD fails to delete you may be experiencing a known issue. Resolve this by running:
+```
+kubectl patch crd/psoplugins.purestorage.com -p '{"metadata":{"finalizers":[]}}' --type=merge
+```
+If you are using OpenShift, replace `kubectl` with `oc` in the above commands.
+
+# License
+https://www.purestorage.com/content/dam/purestorage/pdf/legal/pure-plugin-end-user-license-agmt-sept-18-2017.pdf

--- a/operator-k8s-plugin/install.sh
+++ b/operator-k8s-plugin/install.sh
@@ -2,15 +2,16 @@
 IMAGE=quay.io/purestorage/pso-operator:v0.0.5
 NAMESPACE=pso-operator
 KUBECTL=oc
+ORCHESTRATOR=k8s
 
 usage()
 {
     echo "Usage : $0 --image=<imagename> --namespace=<namespace> --orchestrator=<orchestrator> -f <values.yaml>"
-    exit
 }
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     usage
+    exit
 fi
 
 while (("$#")); do
@@ -53,8 +54,8 @@ case "$1" in
 done
 
 if [[ -z ${VALUESFILE} || ! -f ${VALUESFILE} ]]; then
+    echo "File ${VALUESFILE} does not exist"
     usage
-    echo "File ${VALUESFILE} for values.yaml does not exist"
     exit 1
 fi
 

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -23,7 +23,7 @@ This helm chart installs the CSI plugin on a Kubernetes cluster.
 
 _* Please see release notes for details_
 
-## Additional configuration for Kuberenetes 1.13
+## Additional configuration for Kubernetes 1.13 Only
 For details see the [CSI documentation](https://kubernetes-csi.github.io/docs/csi-driver-object.html). 
 In Kubernetes 1.12 and 1.13 CSI was alpha and is disabled by default. To enable the use of a CSI driver on these versions, do the following:
 


### PR DESCRIPTION
Clarify details for installation of the Operator.
Fix the install script that was not telling you if your specified configuration file didn't exist.
Add the default `values.yaml` file for CSI into the `operator-csi-plugin` directory.