### PR TITLE
allow csi images to be customisable

### DIFF
--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -80,16 +80,12 @@ The following table lists the configurable parameters and their default values.
 | `provisioner.tolerations`               | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts)  | `[]` |
 | `provisioner.affinity`                  | [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) | `{}` |
 | `csi.provisioner.image.name` | The image name of the csi-provisioner | `quay.io/k8scsi/csi-provisioner` |
-| `csi.provisioner.image.tag`  | The image tag of the csi-provisioner | `v1.1.0` |
 | `csi.provisioner.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `csi.clusterDriverRegistrar.image.name` | The image name of the csi-cluster-driver-registrar | `quay.io/k8scsi/csi-cluster-driver-registrar` |
-| `csi.clusterDriverRegistrar.image.tag`  | The image tag of the csi-cluster-driver-registrar | `v1.0.1` |
 | `csi.clusterDriverRegistrar.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `csi.nodeDriverRegistrar.image.name` | The image name of the csi-node-driver-registrar | `quay.io/k8scsi/csi-node-driver-registrar` |
-| `csi.nodeDriverRegistrar.image.tag`  | The image tag of the csi-node-driver-registrar | `v1.1.0` |
 | `csi.nodeDriverRegistrar.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `csi.livenessProbe.image.name` | The image name of the csi livenessprobe | `quay.io/k8scsi/livenessprobe` |
-| `csi.livenessProbe.image.tag`  | The image tag of the csi livenessprobe | `v1.1.0` |
 | `csi.livenessProbe.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 
 *Examples:

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -79,6 +79,18 @@ The following table lists the configurable parameters and their default values.
 | `provisioner.nodeSelector`              | [NodeSelectors](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) Select node-labels to schedule provisioner. | `{}` |
 | `provisioner.tolerations`               | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts)  | `[]` |
 | `provisioner.affinity`                  | [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) | `{}` |
+| `csi.provisioner.image.name` | The image name of the csi-provisioner | `quay.io/k8scsi/csi-provisioner` |
+| `csi.provisioner.image.tag`  | The image tag of the csi-provisioner | `v1.1.0` |
+| `csi.provisioner.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `csi.clusterDriverRegistrar.image.name` | The image name of the csi-cluster-driver-registrar | `quay.io/k8scsi/csi-cluster-driver-registrar` |
+| `csi.clusterDriverRegistrar.image.tag`  | The image tag of the csi-cluster-driver-registrar | `v1.0.1` |
+| `csi.clusterDriverRegistrar.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `csi.nodeDriverRegistrar.image.name` | The image name of the csi-node-driver-registrar | `quay.io/k8scsi/csi-node-driver-registrar` |
+| `csi.nodeDriverRegistrar.image.tag`  | The image tag of the csi-node-driver-registrar | `v1.1.0` |
+| `csi.nodeDriverRegistrar.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `csi.livenessProbe.image.name` | The image name of the csi livenessprobe | `quay.io/k8scsi/livenessprobe` |
+| `csi.livenessProbe.image.tag`  | The image tag of the csi livenessprobe | `v1.1.0` |
+| `csi.livenessProbe.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 
 *Examples:
 ```yaml

--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -81,7 +81,7 @@ spec:
       containers:
         - name: node-driver-registrar
           {{- with .Values.csi.nodeDriverRegistrar.image }}
-          image: "{{ .name }}:{{ .tag }}"
+          image: "{{ .name }}:v1.1.0"
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           lifecycle:
@@ -179,7 +179,7 @@ spec:
           - mountPath: /csi
             name: socket-dir
           {{- with .Values.csi.livenessProbe.image }}
-          image: "{{ .name }}:{{ .tag }}"
+          image: "{{ .name }}:v1.1.0"
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           args:

--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -80,7 +80,10 @@ spec:
       hostPID: true
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          {{- with .Values.csi.nodeDriverRegistrar }}
+          image: "{{ .name }}:{{ .tag }}"
+          imagePullPolicy: {{ .pullPolicy }}
+          {{-end }}
           lifecycle:
             preStop:
               exec:
@@ -175,7 +178,10 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          {{- with .Values.csi.livenessProbe }}
+          image: "{{ .name }}:{{ .tag }}"
+          imagePullPolicy: {{ .pullPolicy }}
+          {{-end }}
           args:
           - --csi-address=/csi/csi.sock
           - --connection-timeout=3s

--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -80,10 +80,10 @@ spec:
       hostPID: true
       containers:
         - name: node-driver-registrar
-          {{- with .Values.csi.nodeDriverRegistrar }}
+          {{- with .Values.csi.nodeDriverRegistrar.image }}
           image: "{{ .name }}:{{ .tag }}"
           imagePullPolicy: {{ .pullPolicy }}
-          {{-end }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -178,10 +178,10 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          {{- with .Values.csi.livenessProbe }}
+          {{- with .Values.csi.livenessProbe.image }}
           image: "{{ .name }}:{{ .tag }}"
           imagePullPolicy: {{ .pullPolicy }}
-          {{-end }}
+          {{- end }}
           args:
           - --csi-address=/csi/csi.sock
           - --connection-timeout=3s

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -69,7 +69,7 @@ spec:
         # This is the external provisioner sidecar
         - name: csi-provisioner
           {{- with .Values.csi.provisioner.image }}
-          image: "{{ .name }}:{{ .tag }}"
+          image: "{{ .name }}:v1.1.0"
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           args:
@@ -84,7 +84,7 @@ spec:
 {{ if and (eq .Capabilities.KubeVersion.Major "1") (eq .Capabilities.KubeVersion.Minor "13") }}
         - name: cluster-driver-registrar
           {{- with .Values.csi.clusterDriverRegistrar.image }}
-          image: "{{ .name }}:{{ .tag }}"
+          image: "{{ .name }}:v1.0.1"
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           args:

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -68,7 +68,10 @@ spec:
 
         # This is the external provisioner sidecar
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.1.0
+          {{- with .Values.csi.provisioner }}
+          image: "{{ .name }}:{{ .tag }}"
+          imagePullPolicy: {{ .pullPolicy }}
+          {{-end }}
           args:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=15s
@@ -80,7 +83,10 @@ spec:
 # The reason we do not want a crd-hook with helm-chart is to avoid upgrade issues like: https://github.com/helm/helm/issues/4489
 {{ if and (eq .Capabilities.KubeVersion.Major "1") (eq .Capabilities.KubeVersion.Minor "13") }}
         - name: cluster-driver-registrar
-          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          {{- with .Values.csi.clusterDriverRegistrar }}
+          image: "{{ .name }}:{{ .tag }}"
+          imagePullPolicy: {{ .pullPolicy }}
+          {{-end }}
           args:
             - "--csi-address=/csi/csi.sock"
             - "--driver-requires-attachment=false"

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -68,10 +68,10 @@ spec:
 
         # This is the external provisioner sidecar
         - name: csi-provisioner
-          {{- with .Values.csi.provisioner }}
+          {{- with .Values.csi.provisioner.image }}
           image: "{{ .name }}:{{ .tag }}"
           imagePullPolicy: {{ .pullPolicy }}
-          {{-end }}
+          {{- end }}
           args:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=15s
@@ -83,10 +83,10 @@ spec:
 # The reason we do not want a crd-hook with helm-chart is to avoid upgrade issues like: https://github.com/helm/helm/issues/4489
 {{ if and (eq .Capabilities.KubeVersion.Major "1") (eq .Capabilities.KubeVersion.Minor "13") }}
         - name: cluster-driver-registrar
-          {{- with .Values.csi.clusterDriverRegistrar }}
+          {{- with .Values.csi.clusterDriverRegistrar.image }}
           image: "{{ .name }}:{{ .tag }}"
           imagePullPolicy: {{ .pullPolicy }}
-          {{-end }}
+          {{- end }}
           args:
             - "--csi-address=/csi/csi.sock"
             - "--driver-requires-attachment=false"

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -7,6 +7,29 @@ image:
   tag: 5.0.0
   pullPolicy: IfNotPresent
 
+csi:
+  provisioner:
+    image:
+      name: quay.io/k8scsi/csi-provisioner
+      tag: v1.1.0
+      pullPolicy: IfNotPresent
+  clusterDriverRegistrar:
+    image:
+      name: quay.io/k8scsi/csi-cluster-driver-registrar
+      tag: v1.0.1
+      pullPolicy: IfNotPresent
+  nodeDriverRegistrar:
+    image:
+      name: quay.io/k8scsi/csi-node-driver-registrar
+      tag: v1.1.0
+      pullPolicy: IfNotPresent
+  livenessProbe:
+    image:
+      name: quay.io/k8scsi/livenessprobe
+      tag: v1.1.0
+      pullPolicy: IfNotPresent
+
+
 # this option is to enable/disable the debug mode of this app
 # for pure-csi-driver
 app:

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -11,22 +11,18 @@ csi:
   provisioner:
     image:
       name: quay.io/k8scsi/csi-provisioner
-      tag: v1.1.0
       pullPolicy: IfNotPresent
   clusterDriverRegistrar:
     image:
       name: quay.io/k8scsi/csi-cluster-driver-registrar
-      tag: v1.0.1
       pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     image:
       name: quay.io/k8scsi/csi-node-driver-registrar
-      tag: v1.1.0
       pullPolicy: IfNotPresent
   livenessProbe:
     image:
       name: quay.io/k8scsi/livenessprobe
-      tag: v1.1.0
       pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
allow all quay.io/k8scsi/* images to be customisable. necessary for those k8s clusters that don't have access to public docker registries.

(I haven't updated `Chart.yaml` and hasn't run`update.sh` yet. Could someone advise where can I find the doc for the release process, please?)