### PR TITLE
Adding the privileged SCC to the CSI operator.

### DIFF
--- a/operator-csi-plugin/install.sh
+++ b/operator-csi-plugin/install.sh
@@ -92,7 +92,8 @@ supplementalGroups:
     if [[ -z ${SVC_ACCNT} ]]; then
         SVC_ACCNT=pure
     fi
-    $KUBECTL adm policy add-scc-to-user hostpath -n ${NAMESPACE} -z ${SVC_ACCNT} 
+    $KUBECTL adm policy add-scc-to-user hostpath -n ${NAMESPACE} -z ${SVC_ACCNT}
+    $KUBECTL adm policy add-scc-to-user privileged -n ${NAMESPACE} -z ${SVC_ACCNT}
 fi
 
 # 2. Create CRD and wait until TIMEOUT seconds for the CRD to be established.


### PR DESCRIPTION
According to https://github.com/purestorage/helm-charts/issues/114#issuecomment-528993222 we need privileged SCC for the CSI operator to properly install the CSI drivers on OpenShift 4.X.

It seems like this is also mentioned here: https://docs.openshift.com/container-platform/3.10/install_config/persistent_storage/persistent_storage_csi.html