### PR TITLE
Add missing CSI Snapshotter sidecar information

### DIFF
--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -92,6 +92,8 @@ The following table lists the configurable parameters and their default values.
 | `csi.nodeDriverRegistrar.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `csi.livenessProbe.image.name` | The image name of the csi livenessprobe | `quay.io/k8scsi/livenessprobe` |
 | `csi.livenessProbe.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `csi.snapshotter.image.name` | The image name of the csi snapshotter | `quay.io/k8scsi/csi-snapshotter` |
+| `csi.snapshotter.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 
 *Examples:
 ```yaml

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -81,6 +81,7 @@ spec:
         - name: csi-snapshotter
           {{- with .Values.csi.snapshotter.image }}
           image: "{{ .name }}:v1.1.0"
+          imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           args:
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
Update README with csi-snapshotter sidecar defaults and add the imagePullPolicy to the template file as this was missed out in the original PR