### PR TITLE
Security fixes for CVE-2019-11255

### DIFF
--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -81,7 +81,7 @@ spec:
       containers:
         - name: node-driver-registrar
           {{- with .Values.csi.nodeDriverRegistrar.image }}
-          image: "{{ .name }}:v1.1.0"
+          image: {{ .name | default "quay.io/k8scsi/csi-node-driver-registrar" }}:v1.1.0
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           lifecycle:
@@ -179,7 +179,7 @@ spec:
           - mountPath: /csi
             name: socket-dir
           {{- with .Values.csi.livenessProbe.image }}
-          image: "{{ .name }}:v1.1.0"
+          image: {{ .name | default "quay.io/k8scsi/livenessprobe" }}:v1.1.0
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           args:

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -69,7 +69,7 @@ spec:
         # This is the external provisioner sidecar
         - name: csi-provisioner
           {{- with .Values.csi.provisioner.image }}
-          image: "{{ .name }}:v1.4.0"
+          image: {{ .name | default "quay.io/k8scsi/csi-provisioner" }}:v1.4.0
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           args:
@@ -80,7 +80,7 @@ spec:
               mountPath: /csi
         - name: csi-snapshotter
           {{- with .Values.csi.snapshotter.image }}
-          image: "{{ .name }}:v1.1.0"
+          image: {{ .name | default "quay.io/k8scsi/csi-snapshotter" }}:v1.2.2
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           args:
@@ -95,7 +95,7 @@ spec:
 {{ if and (eq .Capabilities.KubeVersion.Major "1") (eq .Capabilities.KubeVersion.Minor "13") }}
         - name: cluster-driver-registrar
           {{- with .Values.csi.clusterDriverRegistrar.image }}
-          image: "{{ .name }}:v1.0.1"
+          image: {{ .name | default "quay.io/k8scsi/csi-cluster-driver-registrar" }}:v1.0.1
           imagePullPolicy: {{ .pullPolicy }}
           {{- end }}
           args:


### PR DESCRIPTION
This commit is to address security concerns with presented here: https://issue.k8s.io/85233
The main fix is to upgrade csi-snapshotter to v1.2.2 (has fix) from v1.1.0 (does not have fix).

Also changed the csi image name options in the values file to optional to allow easy upgrade from before we had those options.