### PR TITLE
Add default VolumeSnapshotClass support

### DIFF
--- a/operator-csi-plugin/install.sh
+++ b/operator-csi-plugin/install.sh
@@ -422,3 +422,23 @@ metadata:
 spec:
   # Add fields here' | sed "s|REPLACE_NAMESPACE|${NAMESPACE}|"; sed 's/.*/  &/' ${VALUESFILE}) | ${KUBECTL_NS} -
 
+counter=0
+TIMEOUT=30
+
+while true; do
+   result=$(${KUBECTL} get crd/volumesnapshotclasses.snapshot.storage.k8s.io -o jsonpath='{.status.conditions[?(.type == "Established")].status}{"\n"}' --ignore-not-found | grep -i true)
+  if [ $? -eq 0 ]; then
+     break
+  fi
+  counter=$(($counter+1))
+  if [ $counter -gt $TIMEOUT ]; then
+     break
+  fi
+  sleep 1
+done
+
+if [ $counter -gt $TIMEOUT ]; then
+   echo "VolumeSnapshotClasss CRD not found!"
+else
+    $KUBECTL apply -f ../pure-csi/snapshotclass.yaml
+fi

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -150,6 +150,24 @@ helm install --name pure-storage-driver pure/pure-csi --namespace <namespace> -f
             --set namespace.pure=k8s_xxx \
 ```
 
+## Install the VolumeSnapshotClass
+Make sure you have related CRDs in your system before installing it:
+```
+kubectl get crds
+```
+You should see CRDs like this:
+```
+NAME                                             CREATED AT
+volumesnapshotclasses.snapshot.storage.k8s.io    2019-11-21T17:25:23Z
+volumesnapshotcontents.snapshot.storage.k8s.io   2019-11-21T17:25:23Z
+volumesnapshots.snapshot.storage.k8s.io          2019-11-21T17:25:23Z
+```
+
+To install the VolumeSnapshotClass:
+```
+kubectl apply -f https://github.com/purestorage/helm-charts/blob/master/pure-csi/snapshotclass.yaml
+```
+
 ## How to update `arrays` info
 
 Update your values.yaml with the correct arrays info, and then upgrade the helm as below.

--- a/pure-csi/snapshotclass.yaml
+++ b/pure-csi/snapshotclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshotClass
+metadata:
+   name: pure-snapshotclass
+   annotations:
+   	snapshot.storage.kubernetes.io/is-default-class: "true"
+snapshotter: pure-csi
+reclaimPolicy: Delete
+volumeBindingMode: Immediate


### PR DESCRIPTION
**Summary of changes**
1. Install the VolumesnapshotClass automatically in the CSI operator `install.sh` script.
2. Update helm chart README to guide users to install the VolumesnapshotClass manually.
3. Add the default VolumeSnapshotClass yaml. 