### PR TITLE
Fix 404 when clicking the CSI Snap and Clones documentation in the Readme.md

### DIFF
--- a/operator-csi-plugin/README.md
+++ b/operator-csi-plugin/README.md
@@ -45,7 +45,7 @@ $> kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/master
 
 ## CSI Snapshot and Clone features for Kubernetes
 
-More details on using the snapshot and clone functionality can be found [here](../docs/csi-snapshot-clones.md.md)
+More details on using the snapshot and clone functionality can be found [here](../docs/csi-snapshot-clones.md)
 
 *Note:* It is not currently possible to open feature gates in [AWS EKS](https://github.com/aws/containers-roadmap/issues/512), therefore these features are not available on EKS
 

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -37,7 +37,7 @@ $> kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/master
 
 ## CSI Snapshot and Clone features for Kubernetes
 
-More details on using the snapshot and clone functionality can be found [here](../docs/csi-snapshot-clones.md.md)
+More details on using the snapshot and clone functionality can be found [here](../docs/csi-snapshot-clones.md)
 
 ## How to install
 


### PR DESCRIPTION
currently the link to the ../docs/csi-snapshot-clones.md has a type that says ../docs/csi-snapshot-clones.md.md which returns a 404.
