### PR TITLE
StorageClass FS Options support

### DIFF
--- a/pure-csi/templates/storageclass.yaml
+++ b/pure-csi/templates/storageclass.yaml
@@ -9,7 +9,16 @@ metadata:
 {{ include "pure_csi.labels" . | indent 4}}
 provisioner: pure-csi # This must match the name of the CSIDriver. And the name of the CSI plugin from the RPC 'GetPluginInfo'
 parameters:
-    backend: {{ .Values.storageclass.pureBackend | default "block" | quote }}
+  backend: {{ .Values.storageclass.pureBackend | default "block" | quote }}
+  csi.storage.k8s.io/fstype: {{ .Values.flasharray.defaultFSType | default "xfs" | quote }}
+  createoptions: {{ .Values.flasharray.defaultFSOpt | default "-q" | quote }}
+
+{{- if .Values.flasharray.defaultMountOpt }}
+mountOptions:
+  {{- range .Values.flasharray.defaultMountOpt }}
+  - {{ . }}
+  {{- end }}
+{{- end }}
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -31,4 +40,13 @@ metadata:
 {{ include "pure_csi.labels" . | indent 4}}
 provisioner: pure-csi # This must match the name of the CSIDriver. And the name of the CSI plugin from the RPC 'GetPluginInfo'
 parameters:
-    backend: block
+  backend: block
+  csi.storage.k8s.io/fstype: xfs
+  createoptions: -q
+
+{{- if .Values.flasharray.defaultMountOpt }}
+mountOptions:
+  {{- range .Values.flasharray.defaultMountOpt }}
+  - {{ . }}
+  {{- end }}
+{{- end }}

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -51,7 +51,8 @@ flasharray:
   sanType: ISCSI
   defaultFSType: xfs
   defaultFSOpt: "-q"
-  defaultMountOpt: ""
+  defaultMountOpt:
+    - discard
   preemptAttachments: "true"
   iSCSILoginTimeout: 20
 


### PR DESCRIPTION
**Summary of changes:**
For `pure` and `pure-block` storageclass.
1.  Add ` csi.storage.k8s.io/fstype` and `createoptions` in the parameter key-value map
2. Add `mountOptions`

No change for `pure-file`