### PR TITLE
k8s Api updates for 1.16+

### DIFF
--- a/operator-csi-plugin/install.sh
+++ b/operator-csi-plugin/install.sh
@@ -99,7 +99,7 @@ fi
 counter=0
 TIMEOUT=10
 echo "
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: psoplugins.purestorage.com
@@ -139,7 +139,7 @@ fi
 # 3. Create RBAC for the PSO-Operator
 echo '
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pso-operator
 rules:
@@ -295,7 +295,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pso-operator-role
 subjects:
@@ -309,7 +309,7 @@ roleRef:
 
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pso-operator
 rules:
@@ -362,7 +362,7 @@ rules:
 ---
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: default-account-pso-operator
 subjects:

--- a/operator-csi-plugin/install.sh
+++ b/operator-csi-plugin/install.sh
@@ -152,11 +152,11 @@ rules:
   - apiGroups:
     - purestorage.com
     resources:
-    - "*"
+    - \"*\"
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - namespaces
     verbs:
@@ -166,8 +166,8 @@ rules:
     resources:
     - storageclasses
     verbs:
-    - "create"
-    - "delete"
+    - \"create\"
+    - \"delete\"
 # PSO operator needs to create/delete a ClusterRole and ClusterRoleBinding for provisioning PVs
   - apiGroups:
     - rbac.authorization.k8s.io
@@ -175,9 +175,9 @@ rules:
     - clusterrolebindings
     - clusterroles
     verbs:
-    - "create"
-    - "delete"
-    - "get"
+    - \"create\"
+    - \"delete\"
+    - \"get\"
 # On Openshift ClusterRoleBindings belong to a different apiGroup.
   - apiGroups:
     - authorization.openshift.io
@@ -185,119 +185,119 @@ rules:
     - clusterrolebindings
     - clusterroles
     verbs:
-    - "create"
-    - "delete"
-    - "get"
+    - \"create\"
+    - \"delete\"
+    - \"get\"
 # Need the same permissions as pure-provisioner-clusterrole to be able to create it
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - persistentvolumes
     verbs:
-    - "create"
-    - "delete"
-    - "get"
-    - "list"
-    - "watch"
-    - "update"
+    - \"create\"
+    - \"delete\"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
+    - \"update\"
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - persistentvolumeclaims
     verbs:
-    - "get"
-    - "list"
-    - "update"
-    - "watch"
+    - \"get\"
+    - \"list\"
+    - \"update\"
+    - \"watch\"
   - apiGroups:
     - storage.k8s.io
     resources:
     - storageclasses
     verbs:
-    - "get"
-    - "list"
-    - "watch"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
 # Need the same permissions as external-provisioner-runner clusterrole to be able to create it
   - apiGroups:
-    - ""
+    - \"\"
     resources:
-    - "events"
+    - \"events\"
     verbs:
-    - "create"
-    - "patch"
-    - "update"
-    - "watch"
-    - "list"
-    - "get"
+    - \"create\"
+    - \"patch\"
+    - \"update\"
+    - \"watch\"
+    - \"list\"
+    - \"get\"
   - apiGroups:
     - snapshot.storage.k8s.io
     resources:
-    - "volumesnapshots"
+    - \"volumesnapshots\"
     verbs:
-    - "get"
-    - "list"
-    - "watch"
-    - "update"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
+    - \"update\"
   - apiGroups:
     - snapshot.storage.k8s.io
     resources:
-    - "volumesnapshots/status"
+    - \"volumesnapshots/status\"
     verbs:
-    - "update"
+    - \"update\"
   - apiGroups:
     - snapshot.storage.k8s.io
     resources:
-    - "volumesnapshotcontents"
+    - \"volumesnapshotcontents\"
     verbs:
-    - "create"
-    - "get"
-    - "list"
-    - "watch"
-    - "update"
-    - "delete"
+    - \"create\"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
+    - \"update\"
+    - \"delete\"
   - apiGroups:
     - snapshot.storage.k8s.io
     resources:
-    - "volumesnapshotclasses"
+    - \"volumesnapshotclasses\"
     verbs:
-    - "get"
-    - "list"
-    - "watch"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
   - apiGroups: 
     - storage.k8s.io
     resources: 
-    - "csinodes"
+    - \"csinodes\"
     verbs: 
-    - "get"
-    - "list"
-    - "watch"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
   - apiGroups: 
-    - ""
+    - \"\"
     resources:
-    - "nodes"
+    - \"nodes\"
     verbs:
-    - "get"
-    - "list"
-    - "watch"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
 # Need the same permissions as driver-registrat-runner clusterrole to be able to create it. Only for K8s 1.13
   - apiGroups: 
-    - "apiextensions.k8s.io"
+    - \"apiextensions.k8s.io\"
     resources: 
-    - "customresourcedefinitions"
+    - \"customresourcedefinitions\"
     verbs: 
-    - "*"
+    - \"*\"
   - apiGroups: 
-    - "csi.storage.k8s.io"
+    - \"csi.storage.k8s.io\"
     resources:
-    - "csidrivers"
+    - \"csidrivers\"
     verbs: 
-    - "*"
+    - \"*\"
   - apiGroups: 
-    - "storage.k8s.io"
+    - \"storage.k8s.io\"
     resources:
-    - "csidrivers"
+    - \"csidrivers\"
     verbs: 
-    - "*"
+    - \"*\"
 
 ---
 kind: ClusterRoleBinding
@@ -329,9 +329,9 @@ rules:
     - secrets
     - serviceaccounts
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - namespaces
     verbs:
@@ -343,27 +343,27 @@ rules:
     - daemonsets
     - statefulsets
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
     - extensions
     resources:
     - daemonsets
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
     - rbac.authorization.k8s.io
     resources:
     - roles
     - rolebindings
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
     - authorization.openshift.io
     resources:
     - roles
     - rolebindings
     verbs:
-    - "*"
+    - \"*\"
 
 ---
 
@@ -415,7 +415,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "pso-operator"
+              value: \"pso-operator\"
 " | sed "s|REPLACE_IMAGE|${IMAGE}|" | ${KUBECTL_NS} -
 
 # 5. Use the values.yaml file to create a customized PSO operator instance

--- a/operator-k8s-plugin/install.sh
+++ b/operator-k8s-plugin/install.sh
@@ -152,11 +152,11 @@ rules:
   - apiGroups:
     - purestorage.com
     resources:
-    - "*"
+    - \"*\"
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - namespaces
     verbs:
@@ -166,8 +166,8 @@ rules:
     resources:
     - storageclasses
     verbs:
-    - "create"
-    - "delete"
+    - \"create\"
+    - \"delete\"
 # PSO operator needs to create/delete a ClusterRole and ClusterRoleBinding for provisioning PVs
   - apiGroups:
     - rbac.authorization.k8s.io
@@ -175,9 +175,9 @@ rules:
     - clusterrolebindings
     - clusterroles
     verbs:
-    - "create"
-    - "delete"
-    - "get"
+    - \"create\"
+    - \"delete\"
+    - \"get\"
 # On Openshift ClusterRoleBindings belong to a different apiGroup.
   - apiGroups:
     - authorization.openshift.io
@@ -185,47 +185,47 @@ rules:
     - clusterrolebindings
     - clusterroles
     verbs:
-    - "create"
-    - "delete"
-    - "get"
+    - \"create\"
+    - \"delete\"
+    - \"get\"
 # Need the same permissions as pure-provisioner-clusterrole to be able to create it
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - persistentvolumes
     verbs:
-    - "create"
-    - "delete"
-    - "get"
-    - "list"
-    - "watch"
-    - "update"
+    - \"create\"
+    - \"delete\"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
+    - \"update\"
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - persistentvolumeclaims
     verbs:
-    - "get"
-    - "list"
-    - "update"
-    - "watch"
+    - \"get\"
+    - \"list\"
+    - \"update\"
+    - \"watch\"
   - apiGroups:
     - storage.k8s.io
     resources:
     - storageclasses
     verbs:
-    - "get"
-    - "list"
-    - "watch"
+    - \"get\"
+    - \"list\"
+    - \"watch\"
   - apiGroups:
-    - ""
+    - \"\"
     resources:
-    - "events"
+    - \"events\"
     verbs:
-    - "create"
-    - "patch"
-    - "update"
-    - "watch"
+    - \"create\"
+    - \"patch\"
+    - \"update\"
+    - \"watch\"
 
 ---
 kind: ClusterRoleBinding
@@ -248,7 +248,7 @@ metadata:
   name: pso-operator
 rules:
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - pods
     - services
@@ -257,9 +257,9 @@ rules:
     - secrets
     - serviceaccounts
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
-    - ""
+    - \"\"
     resources:
     - namespaces
     verbs:
@@ -270,27 +270,27 @@ rules:
     - deployments
     - daemonsets
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
     - extensions
     resources:
     - daemonsets
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
     - rbac.authorization.k8s.io
     resources:
     - roles
     - rolebindings
     verbs:
-    - "*"
+    - \"*\"
   - apiGroups:
     - authorization.openshift.io
     resources:
     - roles
     - rolebindings
     verbs:
-    - "*"
+    - \"*\"
 
 ---
 
@@ -342,7 +342,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "pso-operator"
+              value: \"pso-operator\"
 " | sed "s|REPLACE_IMAGE|${IMAGE}|" | ${KUBECTL_NS} -
 
 # 5. Use the values.yaml file to create a customized PSO operator instance

--- a/operator-k8s-plugin/install.sh
+++ b/operator-k8s-plugin/install.sh
@@ -99,7 +99,7 @@ fi
 counter=0
 TIMEOUT=10
 echo "
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: psoplugins.purestorage.com
@@ -139,7 +139,7 @@ fi
 # 3. Create RBAC for the PSO-Operator
 echo '
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pso-operator
 rules:
@@ -223,7 +223,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pso-operator-role
 subjects:
@@ -237,7 +237,7 @@ roleRef:
 
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pso-operator
 rules:
@@ -289,7 +289,7 @@ rules:
 ---
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: default-account-pso-operator
 subjects:

--- a/operator-k8s-plugin/install.sh
+++ b/operator-k8s-plugin/install.sh
@@ -3,6 +3,12 @@ IMAGE=quay.io/purestorage/pso-operator:v0.0.7
 NAMESPACE=pso-operator
 KUBECTL=oc
 ORCHESTRATOR=k8s
+CRDAPIVERSION="$(${KUBECTL} explain CustomResourceDefinition | grep "VERSION:" | awk '{ print $2 }')"
+CLUSTERROLEAPIVERSION="$(${KUBECTL} explain ClusterRole | grep "VERSION:" | awk '{ print $2 }')"
+CLUSTERROLEBINDINGAPIVERSION="$(${KUBECTL} explain ClusterRoleBinding | grep "VERSION:" | awk '{ print $2 }')"
+ROLEAPIVERSION="$(${KUBECTL} explain Role | grep "VERSION:" | awk '{ print $2 }')"
+ROLEBINDINGAPIVERSION="$(${KUBECTL} explain RoleBinding | grep "VERSION:" | awk '{ print $2 }')"
+DEPLOYMENTAPIVERSION="$(${KUBECTL} explain Deployment | grep "VERSION:" | awk '{ print $2 }')"
 
 usage()
 {
@@ -99,7 +105,7 @@ fi
 counter=0
 TIMEOUT=10
 echo "
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: ${CRDAPIVERSION}
 kind: CustomResourceDefinition
 metadata:
   name: psoplugins.purestorage.com
@@ -137,9 +143,9 @@ fi
 
 
 # 3. Create RBAC for the PSO-Operator
-echo '
+echo "
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: ${CLUSTERROLEAPIVERSION}
 metadata:
   name: pso-operator
 rules:
@@ -223,7 +229,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: ${CLUSTERROLEBINDINGAPIVERSION}
 metadata:
   name: pso-operator-role
 subjects:
@@ -237,7 +243,7 @@ roleRef:
 
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: ${ROLEAPIVERSION}
 metadata:
   name: pso-operator
 rules:
@@ -289,7 +295,7 @@ rules:
 ---
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: ${ROLEBINDINGAPIVERSION}
 metadata:
   name: default-account-pso-operator
 subjects:
@@ -299,11 +305,11 @@ roleRef:
   kind: Role
   name: pso-operator
   apiGroup: rbac.authorization.k8s.io
-' | sed "s|REPLACE_NAMESPACE|${NAMESPACE}|" | ${KUBECTL_NS} -
+" | sed "s|REPLACE_NAMESPACE|${NAMESPACE}|" | ${KUBECTL_NS} -
 
 # 4. Create a PSO-Operator Deployment
-echo '
-apiVersion: apps/v1
+echo "
+apiVersion: ${DEPLOYMENTAPIVERSION}
 kind: Deployment
 metadata:
   name: pso-operator
@@ -337,7 +343,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "pso-operator"
-' | sed "s|REPLACE_IMAGE|${IMAGE}|" | ${KUBECTL_NS} -
+" | sed "s|REPLACE_IMAGE|${IMAGE}|" | ${KUBECTL_NS} -
 
 # 5. Use the values.yaml file to create a customized PSO operator instance
 ( echo '

--- a/pure-csi/templates/_helpers.tpl
+++ b/pure-csi/templates/_helpers.tpl
@@ -65,9 +65,9 @@ Return the appropriate apiVersion for RBAC APIs.
 */}}
 {{- define "rbac.apiVersion" -}}
 {{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion -}}
-"rbac.authorization.k8s.io/v1"
+{{- print "rbac.authorization.k8s.io/v1" -}}
 {{- else -}}
-"rbac.authorization.k8s.io/v1beta1"
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
 

--- a/pure-csi/templates/_helpers.tpl
+++ b/pure-csi/templates/_helpers.tpl
@@ -42,7 +42,7 @@ Create chart name and version as used by the chart label.
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "deployment.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apps/v1" -}}
 {{- else -}}
 {{- print "apps/v1beta1" -}}
@@ -53,7 +53,7 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiVersion for daemonset.
 */}}
 {{- define "daemonset.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apps/v1" -}}
 {{- else -}}
 {{- print "apps/v1beta1" -}}

--- a/pure-csi/templates/_helpers.tpl
+++ b/pure-csi/templates/_helpers.tpl
@@ -37,3 +37,47 @@ Create chart name and version as used by the chart label.
 {{- define "pure-csi.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- else -}}
+{{- print "apps/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for daemonset.
+*/}}
+{{- define "daemonset.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- else -}}
+{{- print "apps/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for RBAC APIs.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+"rbac.authorization.k8s.io/v1"
+{{- else -}}
+"rbac.authorization.k8s.io/v1beta1"
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "statefulset.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -53,7 +53,7 @@ spec:
 {{ end }}
 ---
 kind: DaemonSet
-apiVersion: apps/v1
+apiVersion: {{ template "daemonset.apiVersion" . }}
 metadata:
   name: pure-csi
   namespace: {{ .Release.Namespace }}

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -17,7 +17,7 @@ spec:
 # Why does this need to be a statefulset?
 # Because we need only one copy of the provisioner running
 kind: StatefulSet
-apiVersion: apps/v1
+apiVersion: {{ template "statefulset.apiVersion" . }}
 metadata:
   name: pure-provisioner
   namespace: {{ .Release.Namespace }}

--- a/pure-csi/templates/rbac.yaml
+++ b/pure-csi/templates/rbac.yaml
@@ -19,7 +19,7 @@ metadata:
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: external-provisioner-runner
   labels:
@@ -66,7 +66,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: csi-provisioner-role
   labels:
@@ -82,7 +82,7 @@ roleRef:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: csi-snapshotter-role
   labels:
@@ -115,7 +115,7 @@ roleRef:
 #   this influences the RBAC setup, see below
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: driver-registrar-runner
   labels:
@@ -143,7 +143,7 @@ rules:
     verbs: ['*']
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: csi-driver-registrar-role
   labels:

--- a/pure-k8s-plugin/templates/_helpers.tpl
+++ b/pure-k8s-plugin/templates/_helpers.tpl
@@ -45,9 +45,9 @@ Return the appropriate apiVersion for RBAC APIs.
 */}}
 {{- define "rbac.apiVersion" -}}
 {{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion -}}
-"rbac.authorization.k8s.io/v1"
+{{- print "rbac.authorization.k8s.io/v1" -}}
 {{- else -}}
-"rbac.authorization.k8s.io/v1beta1"
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
 

--- a/pure-k8s-plugin/templates/_helpers.tpl
+++ b/pure-k8s-plugin/templates/_helpers.tpl
@@ -22,7 +22,7 @@ release: {{ .Release.Name | quote }}
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "deployment.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apps/v1" -}}
 {{- else -}}
 {{- print "apps/v1beta1" -}}
@@ -33,7 +33,7 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiVersion for daemonset.
 */}}
 {{- define "daemonset.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apps/v1" -}}
 {{- else -}}
 {{- print "apps/v1beta1" -}}

--- a/pure-k8s-plugin/templates/_helpers.tpl
+++ b/pure-k8s-plugin/templates/_helpers.tpl
@@ -17,3 +17,37 @@ release: {{ .Release.Name | quote }}
 {{ .Values.orchestrator.openshift.flexPath }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- else -}}
+{{- print "apps/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for daemonset.
+*/}}
+{{- define "daemonset.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- else -}}
+{{- print "apps/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for RBAC APIs.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+"rbac.authorization.k8s.io/v1"
+{{- else -}}
+"rbac.authorization.k8s.io/v1beta1"
+{{- end -}}
+{{- end -}}
+

--- a/pure-k8s-plugin/templates/clusterrolebinding.yaml
+++ b/pure-k8s-plugin/templates/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -30,7 +30,7 @@ rules:
 ---
 
 # Assign cluster role to the service account
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pure-provisioner-rights
@@ -47,7 +47,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: pure-provisioner-role
@@ -62,7 +62,7 @@ rules:
 ---
 
 # Assign role to the service account
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pure-provisioner-rights-ns

--- a/pure-k8s-plugin/templates/clusterrolebinding.yaml
+++ b/pure-k8s-plugin/templates/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:
@@ -30,7 +30,7 @@ rules:
 ---
 
 # Assign cluster role to the service account
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: pure-provisioner-rights
@@ -47,7 +47,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: pure-provisioner-role
@@ -62,7 +62,7 @@ rules:
 ---
 
 # Assign role to the service account
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: pure-provisioner-rights-ns

--- a/pure-k8s-plugin/templates/pure-flex-daemon.yaml
+++ b/pure-k8s-plugin/templates/pure-flex-daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "daemonset.apiVersion" . }}
 kind: DaemonSet
 metadata:
   name: pure-flex

--- a/pure-k8s-plugin/templates/pure-flex-daemon.yaml
+++ b/pure-k8s-plugin/templates/pure-flex-daemon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: pure-flex

--- a/pure-k8s-plugin/templates/pure-provisioner.yaml
+++ b/pure-k8s-plugin/templates/pure-provisioner.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: pure-provisioner

--- a/pure-k8s-plugin/templates/pure-provisioner.yaml
+++ b/pure-k8s-plugin/templates/pure-provisioner.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pure-provisioner


### PR DESCRIPTION
Several v1beta1 apis where deprecated in k8s 1.16+

This should help address issues like - https://github.com/purestorage/helm-charts/issues/142

Currently I am unable to use the plugin on my k8s 1.16.3 cluster