### PR TITLE
Remove old beta reference in default storageclass definition

### DIFF
--- a/pure-csi/templates/storageclass.yaml
+++ b/pure-csi/templates/storageclass.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: pure
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "{{ .Values.storageclass.isPureDefault }}"
+    storageclass.kubernetes.io/is-default-class: "{{ .Values.storageclass.isPureDefault }}"
   labels:
     kubernetes.io/cluster-service: "true"
 {{ include "pure_csi.labels" . | indent 4}}

--- a/pure-k8s-plugin/templates/storageclass.yaml
+++ b/pure-k8s-plugin/templates/storageclass.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: pure
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "{{ .Values.storageclass.isPureDefault }}"
+    storageclass.kubernetes.io/is-default-class: "{{ .Values.storageclass.isPureDefault }}"
   labels:
     kubernetes.io/cluster-service: "true"
 {{ include "pure_k8s_plugin.labels" . | indent 4}}


### PR DESCRIPTION
Given we are using the v1 API for storage we should not be using the beta annotation name. This will be removed at some point in the future from the v1 API so we should use the correct annotation key.
The v1 API for storage was added back in v1.6 of k8s so we should have no issue with this change as this was prior to the minimum k8s version supported by PSO