### PR TITLE
Convert helm-chart defaultMountOpt from a slice to a string

### DIFF
--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -135,8 +135,12 @@ spec:
              value: {{ .Values.flasharray.defaultFSType }}
            - name: PURE_DEFAULT_BLOCK_FS_OPT
              value: "{{ .Values.flasharray.defaultFSOpt }}"
+{{- $defaultMountOptString := "" }}
+{{- range .Values.flasharray.defaultMountOpt }}
+{{- $defaultMountOptString = printf "%s %s" $defaultMountOptString . }}
+{{- end}}
            - name: PURE_DEFAULT_BLOCK_MNT_OPT
-             value: "{{ .Values.flasharray.defaultMountOpt }}"
+             value: "{{$defaultMountOptString |trim}}"
            - name: PURE_PREEMPT_RWO_ATTACHMENTS_DEFAULT
              value: "{{ .Values.flasharray.preemptAttachments }}"
            - name: PURE_ISCSI_ALLOWED_CIDRS


### PR DESCRIPTION
**Summary of changes:**
We recently changed the helm-charts "defaultMountOpt" variable in the `value.yaml` from
```
defaultMountOpt: ""
```
to 
```
  defaultMountOpt:
    - discard
```  
This change changes the `defaultMountOpt` data type from string to slice. When helm converts slice to string it will add extra brackets "[]" and make the output string become `"[discard]"` and failed the volume mount. The bug appears when users use a storageclass without `mountOptions` and driver load the default value from `PURE_DEFAULT_BLOCK_MNT_OPT` environment variable. The fix should covert `defaultMountOpt` back to a string and load it through the `PURE_DEFAULT_BLOCK_MNT_OPT`environment variable. 
