### PR TITLE
Add option to override creation of built-in StorageClasses

### DIFF
--- a/pure-csi/templates/storageclass.yaml
+++ b/pure-csi/templates/storageclass.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.storageclass.createBuiltIn }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -49,4 +50,5 @@ mountOptions:
   {{- range .Values.flasharray.defaultMountOpt }}
   - {{ . }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -37,6 +37,8 @@ app:
 
 # do you want to set pure as the default storageclass?
 storageclass:
+  # create the built-in StorageClasses 'pure', 'pure-file' and 'pure-block'?
+  createBuiltIn: true
   isPureDefault: false
   # set the type of backend you want for the 'pure' storageclass
   # pureBackend: file

--- a/pure-k8s-plugin/templates/storageclass.yaml
+++ b/pure-k8s-plugin/templates/storageclass.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.storageclass.createBuiltIn }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -32,3 +33,4 @@ metadata:
 provisioner: pure-provisioner
 parameters:
     backend: block
+{{- end }}

--- a/pure-k8s-plugin/values.yaml
+++ b/pure-k8s-plugin/values.yaml
@@ -14,6 +14,8 @@ app:
 
 # do you want to set pure as the default storageclass?
 storageclass:
+  # create the built-in StorageClasses 'pure', 'pure-file' and 'pure-block'?
+  createBuiltIn: true
   isPureDefault: false
   # set the type of backend you want for the 'pure' storageclass
   # pureBackend: file


### PR DESCRIPTION
This PR introduces the option for the chart user to not create the three built-in StorageClasses `pure`, `pure-file` and `pure-block`.

While this creation is handy for test clusters, production cluster will probably (like us) use a standardized StorageClass name based on the capabilities/purpose of each backing device. Not obligating the user to have these 3 classes when using the chart should help the sysadmins to maintain a clean list for the users.