### PR TITLE
Support either string or list value for flasharray defaultMountOpt

### DIFF
--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -136,8 +136,13 @@ spec:
            - name: PURE_DEFAULT_BLOCK_FS_OPT
              value: "{{ .Values.flasharray.defaultFSOpt }}"
 {{- $defaultMountOptString := "" }}
-{{- range .Values.flasharray.defaultMountOpt }}
-{{- $defaultMountOptString = printf "%s %s" $defaultMountOptString . }}
+# support either string or list for .Values.flasharray.defaultMountOpt
+{{- if kindIs "string" .Values.flasharray.defaultMountOpt }}
+  {{- $defaultMountOptString = .Values.flasharray.defaultMountOpt }}
+{{- else if or (kindIs "array" .Values.flasharray.defaultMountOpt) (kindIs "slice" .Values.flasharray.defaultMountOpt) }}
+  {{- range .Values.flasharray.defaultMountOpt }}
+    {{- $defaultMountOptString = printf "%s %s" $defaultMountOptString . }}
+  {{- end}}
 {{- end}}
            - name: PURE_DEFAULT_BLOCK_MNT_OPT
              value: "{{$defaultMountOptString |trim}}"

--- a/pure-csi/templates/storageclass.yaml
+++ b/pure-csi/templates/storageclass.yaml
@@ -12,12 +12,15 @@ parameters:
   backend: {{ .Values.storageclass.pureBackend | default "block" | quote }}
   csi.storage.k8s.io/fstype: {{ .Values.flasharray.defaultFSType | default "xfs" | quote }}
   createoptions: {{ .Values.flasharray.defaultFSOpt | default "-q" | quote }}
-
-{{- if .Values.flasharray.defaultMountOpt }}
+# support either string or list for .Values.flasharray.defaultMountOpt
+{{- if or (kindIs "array" .Values.flasharray.defaultMountOpt) (kindIs "slice" .Values.flasharray.defaultMountOpt) }}
 mountOptions:
   {{- range .Values.flasharray.defaultMountOpt }}
   - {{ . }}
   {{- end }}
+{{- else if kindIs "string" .Values.flasharray.defaultMountOpt}}
+mountOptions:
+  - {{ .Values.flasharray.defaultMountOpt }}
 {{- end }}
 ---
 kind: StorageClass
@@ -43,10 +46,13 @@ parameters:
   backend: block
   csi.storage.k8s.io/fstype: xfs
   createoptions: -q
-
-{{- if .Values.flasharray.defaultMountOpt }}
+# support either string or list for .Values.flasharray.defaultMountOpt
+{{- if or (kindIs "array" .Values.flasharray.defaultMountOpt) (kindIs "slice" .Values.flasharray.defaultMountOpt) }}
 mountOptions:
   {{- range .Values.flasharray.defaultMountOpt }}
   - {{ . }}
   {{- end }}
+{{- else if kindIs "string" .Values.flasharray.defaultMountOpt}}
+mountOptions:
+  - {{ .Values.flasharray.defaultMountOpt }}
 {{- end }}


### PR DESCRIPTION
When file system options were released in 5.0.5, the defaultMountOpt
in values.yaml changed from a string to a list.
For backwards compatibility, we should continue to support string values.