### PR TITLE
Added an orchestrator basePath value to the CSI chart

### DIFF
--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -91,6 +91,7 @@ The following table lists the configurable parameters and their default values.
 | `flashblade.snapshotDirectoryEnabled`  | Enable/Disable FlashBlade snapshots |     `false`    |
 | `namespace.pure`            | Namespace for the backend storage  | `k8s`                                     |
 | `orchestrator.name`         | Orchestrator type, such as openshift, k8s | `k8s`                              |
+| `orchestrator.basePath`     | Base path of the Kubelet, should contain the `plugins`, `plugins_registry`, and `pods` directories. | `/var/lib/kubelet`                              |
 | *`arrays`                    | Array list of all the backend FlashArrays and FlashBlades | must be set by user, see an example below                |
 | `mounter.nodeSelector`              | [NodeSelectors](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) Select node-labels to schedule CSI node plugin. | `{}` |
 | `mounter.tolerations`               | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts)  | `[]` |

--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -90,7 +90,7 @@ spec:
                 command: ["/bin/sh", "-c", "rm -rf /registration/pure-csi /registration/pure-csi-reg.sock"]
           args:
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/pure-csi/csi.sock
+            - --kubelet-registration-path={{ .Values.orchestrator.basePath }}/plugins/pure-csi/csi.sock
           securityContext:
             privileged: true
           env:
@@ -204,19 +204,19 @@ spec:
             path: /dev
           name: dev
         - hostPath:
-            path: /var/lib/kubelet/plugins/pure-csi
+            path: {{ .Values.orchestrator.basePath }}/plugins/pure-csi
             type: DirectoryOrCreate
           name: socket-dir
         - hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.orchestrator.basePath }}/pods
             type: DirectoryOrCreate
           name: mountpoint-dir
         - hostPath:
-            path: /var/lib/kubelet/plugins_registry
+            path: {{ .Values.orchestrator.basePath }}/plugins_registry
             type: Directory
           name: registration-dir
         - hostPath:
-            path: /var/lib/kubelet/plugins
+            path: {{ .Values.orchestrator.basePath }}/plugins
             type: Directory
           name: plugins-dir
         - hostPath:

--- a/pure-csi/templates/node.yaml
+++ b/pure-csi/templates/node.yaml
@@ -90,7 +90,7 @@ spec:
                 command: ["/bin/sh", "-c", "rm -rf /registration/pure-csi /registration/pure-csi-reg.sock"]
           args:
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path={{ .Values.orchestrator.basePath }}/plugins/pure-csi/csi.sock
+            - --kubelet-registration-path={{ .Values.orchestrator.basePath | default "/var/lib/kubelet" }}/plugins/pure-csi/csi.sock
           securityContext:
             privileged: true
           env:
@@ -204,19 +204,19 @@ spec:
             path: /dev
           name: dev
         - hostPath:
-            path: {{ .Values.orchestrator.basePath }}/plugins/pure-csi
+            path: {{ .Values.orchestrator.basePath | default "/var/lib/kubelet" }}/plugins/pure-csi
             type: DirectoryOrCreate
           name: socket-dir
         - hostPath:
-            path: {{ .Values.orchestrator.basePath }}/pods
+            path: {{ .Values.orchestrator.basePath | default "/var/lib/kubelet" }}/pods
             type: DirectoryOrCreate
           name: mountpoint-dir
         - hostPath:
-            path: {{ .Values.orchestrator.basePath }}/plugins_registry
+            path: {{ .Values.orchestrator.basePath | default "/var/lib/kubelet" }}/plugins_registry
             type: Directory
           name: registration-dir
         - hostPath:
-            path: {{ .Values.orchestrator.basePath }}/plugins
+            path: {{ .Values.orchestrator.basePath | default "/var/lib/kubelet" }}/plugins
             type: Directory
           name: plugins-dir
         - hostPath:

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -69,6 +69,9 @@ namespace:
 orchestrator:
   # name is either 'k8s' or 'openshift'
   name: k8s
+  # Use this to specify the base path of Kubelet. It should contain the "plugins", "plugins_registry", and "pods" directories.
+  # Default is /var/lib/kubelet. For CoreOS and Rancher, this is usually /opt/rke/var/lib/kubelet unless configured otherwise.
+  basePath: /var/lib/kubelet
 
 # arrays specify what storage arrays should be managed by the plugin, this is
 # required to be set upon installation. For FlashArrays you must set the "MgmtEndPoint"


### PR DESCRIPTION
This is used to specify where the base Kubelet path is. The main use case is for something like CoreOS, where /var/lib/kubelet is read-only and a different directory must be used.

This has been tested on Kubernetes 1.14 and 1.16, both change the necessary parameters so that it works as expected. The Flex chart already has a similar value, so no changes are required.