### PR TITLE
Conditionally install daemonset to configure nodes in GKE. 

### DIFF
--- a/pure-csi/templates/node-configure.yaml
+++ b/pure-csi/templates/node-configure.yaml
@@ -1,0 +1,25 @@
+# Automatic node configuration has only been tested on GKE.
+{{ if (.Capabilities.KubeVersion.GitVersion | regexMatch "gke") }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: pso-daemonset
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      name: pso-daemonset
+  template:
+    metadata:
+      labels:
+        name: pso-daemonset
+    spec:
+      hostPID: true
+      containers:
+      - name: pso-daemonset
+        image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/sh", "-c", "/node-configure.sh"]
+        securityContext:
+          privileged: true
+{{ end }}

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -78,6 +78,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+# Google Anthos (which is built on GKE) prohibits alpha snapshotters
+{{- if not (.Capabilities.KubeVersion.GitVersion | regexMatch "gke") }}
         - name: csi-snapshotter
           {{- with .Values.csi.snapshotter.image }}
           image: {{ .name | default "quay.io/k8scsi/csi-snapshotter" }}:v1.2.2
@@ -90,6 +92,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+{{- end }}
 # This is the cluster-driver-registrar sidecar that allows helm-install without CRD-hooks for the CSIDriver CRD
 # The reason we do not want a crd-hook with helm-chart is to avoid upgrade issues like: https://github.com/helm/helm/issues/4489
 {{ if and (eq .Capabilities.KubeVersion.Major "1") (eq .Capabilities.KubeVersion.Minor "13") }}


### PR DESCRIPTION
The daemonset invokes a script from the PSO image that is responsible for preparing GKE nodes for use. At the time of writing this includes installing open-iscsi and multipath-tools
as well as configuring and enabling iscsid.

Conditionally disable csi-snapshotter in GKE. A requirement for Anthos is that we do not enable any alpha features.

This PR depends on https://github.dev.purestorage.com/pso/k8s/pull/162

Together, this enables installation of PSO on Google Anthos and satisfies Google's tests for GKE 1.2.1.