### PR TITLE
Fix openAPIV3Schema which leads PSOPlugin spec empty

### DIFF
--- a/operator-csi-plugin/install.sh
+++ b/operator-csi-plugin/install.sh
@@ -126,8 +126,13 @@ spec:
     storage: true
     schema:
       openAPIV3Schema:
-        type: object
         properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
           spec:
             type: object " | ${KUBECTL} apply -f -
 elif [[ ${CRDAPIVERSION} == "apiextensions.k8s.io/v1beta1" ]]; then
@@ -294,15 +299,15 @@ rules:
     - \"get\"
     - \"list\"
     - \"watch\"
-  - apiGroups: 
+  - apiGroups:
     - storage.k8s.io
-    resources: 
+    resources:
     - \"csinodes\"
-    verbs: 
+    verbs:
     - \"get\"
     - \"list\"
     - \"watch\"
-  - apiGroups: 
+  - apiGroups:
     - \"\"
     resources:
     - \"nodes\"
@@ -311,23 +316,23 @@ rules:
     - \"list\"
     - \"watch\"
 # Need the same permissions as driver-registrat-runner clusterrole to be able to create it. Only for K8s 1.13
-  - apiGroups: 
+  - apiGroups:
     - \"apiextensions.k8s.io\"
-    resources: 
+    resources:
     - \"customresourcedefinitions\"
-    verbs: 
+    verbs:
     - \"*\"
-  - apiGroups: 
+  - apiGroups:
     - \"csi.storage.k8s.io\"
     resources:
     - \"csidrivers\"
-    verbs: 
+    verbs:
     - \"*\"
-  - apiGroups: 
+  - apiGroups:
     - \"storage.k8s.io\"
     resources:
     - \"csidrivers\"
-    verbs: 
+    verbs:
     - \"*\"
 
 ---

--- a/operator-k8s-plugin/install.sh
+++ b/operator-k8s-plugin/install.sh
@@ -126,8 +126,13 @@ spec:
     storage: true
     schema:
       openAPIV3Schema:
-        type: object
         properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
           spec:
             type: object " | ${KUBECTL} apply -f -
 elif [[ ${CRDAPIVERSION} == "apiextensions.k8s.io/v1beta1" ]]; then


### PR DESCRIPTION
# Summary of changes
* Fix the openAPIV3Schema bug

## PSOPlugin before fix 
```bash
apiVersion: purestorage.com/v1
kind: PSOPlugin
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"purestorage.com/v1","kind":"PSOPlugin","metadata":{"annotations":{},"name":"psoplugin-operator","namespace":"pure-csi-operator"},"spec":{"app":{"debug":false},"arrays":{"FlashBlades":[{"APIToken":"T-a8de4ff9-4abf-4b26-a9bf-6139f655e8bc","MgmtEndPoint":"10.14.201.176","NfsEndPoint":"10.16.59.28"}]},"clusterrolebinding":{"serviceAccount":{"name":"pure"}},"csi":{"clusterDriverRegistrar":{"image":{"name":"quay.io/k8scsi/csi-cluster-driver-registrar","pullPolicy":"Always"}},"livenessProbe":{"image":{"name":"quay.io/k8scsi/livenessprobe","pullPolicy":"Always"}},"nodeDriverRegistrar":{"image":{"name":"quay.io/k8scsi/csi-node-driver-registrar","pullPolicy":"Always"}},"provisioner":{"image":{"name":"quay.io/k8scsi/csi-provisioner","pullPolicy":"Always"}},"snapshotter":{"image":{"name":"quay.io/k8scsi/csi-snapshotter","pullPolicy":"Always"}}},"flashblade":{"snapshotDirectoryEnabled":"false"},"image":{"name":"purestorage/k8s","pullPolicy":"Always","tag":"5.0.6"},"mounter":{"affinity":{},"nodeSelector":{},"tolerations":[]},"namespace":{"pure":"openshift"},"orchestrator":{"name":"openshift"},"provisioner":{"affinity":{},"nodeSelector":{},"tolerations":[]},"storageclass":{"isPureDefault":false,"pureBackend":"file"}}}
  creationTimestamp: 2020-02-20T23:03:49Z
  finalizers:
  - uninstall-helm-release
  generation: 1
  name: psoplugin-operator
  namespace: pure-csi-operator
  resourceVersion: "235137"
  selfLink: /apis/purestorage.com/v1/namespaces/pure-csi-operator/psoplugins/psoplugin-operator
  uid: 22628724-a38f-4970-87b5-565aac84c04c
spec: {}
```
## PSOPlugin after fix 
```bash
# kubectl get PSOPlugin psoplugin-operator -o yaml -n pure-csi-operator
apiVersion: purestorage.com/v1
kind: PSOPlugin
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"purestorage.com/v1","kind":"PSOPlugin","metadata":{"annotations":{},"name":"psoplugin-operator","namespace":"pure-csi-operator"},"spec":{"app":{"debug":false},"arrays":{"FlashBlades":[{"APIToken":"T-a8de4ff9-4abf-4b26-a9bf-6139f655e8bc","MgmtEndPoint":"10.14.201.176","NfsEndPoint":"10.16.59.28"}]},"clusterrolebinding":{"serviceAccount":{"name":"pure"}},"csi":{"clusterDriverRegistrar":{"image":{"name":"quay.io/k8scsi/csi-cluster-driver-registrar","pullPolicy":"Always"}},"livenessProbe":{"image":{"name":"quay.io/k8scsi/livenessprobe","pullPolicy":"Always"}},"nodeDriverRegistrar":{"image":{"name":"quay.io/k8scsi/csi-node-driver-registrar","pullPolicy":"Always"}},"provisioner":{"image":{"name":"quay.io/k8scsi/csi-provisioner","pullPolicy":"Always"}},"snapshotter":{"image":{"name":"quay.io/k8scsi/csi-snapshotter","pullPolicy":"Always"}}},"flashblade":{"snapshotDirectoryEnabled":"false"},"image":{"name":"purestorage/k8s","pullPolicy":"Always","tag":"5.0.6"},"mounter":{"affinity":{},"nodeSelector":{},"tolerations":[]},"namespace":{"pure":"openshift"},"orchestrator":{"name":"openshift"},"provisioner":{"affinity":{},"nodeSelector":{},"tolerations":[]},"storageclass":{"isPureDefault":false,"pureBackend":"file"}}}
  creationTimestamp: 2020-02-21T18:08:08Z
  finalizers:
  - uninstall-helm-release
  generation: 1
  name: psoplugin-operator
  namespace: pure-csi-operator
  resourceVersion: "351004"
  selfLink: /apis/purestorage.com/v1/namespaces/pure-csi-operator/psoplugins/psoplugin-operator
  uid: f448573f-4af1-4cb6-8532-e5ecb69fe761
spec:
  app:
    debug: false
  arrays:
    FlashBlades:
    - APIToken: T-a8de4ff9-4abf-4b26-a9bf-6139f655e8bc
      MgmtEndPoint: 10.14.201.176
      NfsEndPoint: 10.16.59.28
  clusterrolebinding:
    serviceAccount:
      name: pure
  csi:
    clusterDriverRegistrar:
      image:
        name: quay.io/k8scsi/csi-cluster-driver-registrar
        pullPolicy: Always
    livenessProbe:
      image:
        name: quay.io/k8scsi/livenessprobe
        pullPolicy: Always
    nodeDriverRegistrar:
      image:
        name: quay.io/k8scsi/csi-node-driver-registrar
        pullPolicy: Always
    provisioner:
      image:
        name: quay.io/k8scsi/csi-provisioner
        pullPolicy: Always
    snapshotter:
      image:
        name: quay.io/k8scsi/csi-snapshotter
        pullPolicy: Always
  flashblade:
    snapshotDirectoryEnabled: "false"
  image:
    name: purestorage/k8s
    pullPolicy: Always
    tag: 5.0.6
  mounter:
    affinity: {}
    nodeSelector: {}
    tolerations: []
  namespace:
    pure: openshift
  orchestrator:
    name: openshift
  provisioner:
    affinity: {}
    nodeSelector: {}
    tolerations: []
  storageclass:
    isPureDefault: false
    pureBackend: file
status:
  conditions:
  - lastTransitionTime: 2020-02-21T18:08:11Z
    status: "True"
    type: Initialized
  - lastTransitionTime: 2020-02-21T18:08:12Z
    reason: InstallSuccessful
    status: "True"
    type: Deployed
  deployedRelease:
    manifest: |2-

      ---
      # Source: pure-csi/templates/secret.yaml
      apiVersion: v1
      data:
        pure.json: eyJGbGFzaEJsYWRlcyI6W3siQVBJVG9rZW4iOiJULWE4ZGU0ZmY5LTRhYmYtNGIyNi1hOWJmLTYxMzlmNjU1ZThiYyIsIk1nbXRFbmRQb2ludCI6IjEwLjE0LjIwMS4xNzYiLCJOZnNFbmRQb2ludCI6IjEwLjE2LjU5LjI4In1dfQ==
      kind: Secret
      metadata:
        labels:
          chart: pure-csi
          generator: helm
          release: psoplugin-operator
        name: pure-provisioner-secret
        namespace: pure-csi-operator
        ownerReferences:
        - apiVersion: purestorage.com/v1
          blockOwnerDeletion: true
          controller: true
          kind: PSOPlugin
          name: psoplugin-operator
          uid: f448573f-4af1-4cb6-8532-e5ecb69fe761
      ---
      # Source: pure-csi/templates/storageclass.yaml
      apiVersion: storage.k8s.io/v1
      kind: StorageClass
      metadata:
        annotations:
          storageclass.kubernetes.io/is-default-class: "false"
        labels:
          chart: pure-csi
          generator: helm
          kubernetes.io/cluster-service: "true"
          release: psoplugin-operator
        name: pure
      mountOptions:
      - discard
      parameters:
        backend: file
        createoptions: -q
        csi.storage.k8s.io/fstype: xfs
      provisioner: pure-csi
      ---
      # Source: pure-csi/templates/storageclass.yaml
      apiVersion: storage.k8s.io/v1
      kind: StorageClass
      metadata:
        labels:
          chart: pure-csi
          generator: helm
          kubernetes.io/cluster-service: "true"
          release: psoplugin-operator
        name: pure-block
      mountOptions:
      - discard
      parameters:
        backend: block
        createoptions: -q
        csi.storage.k8s.io/fstype: xfs
      provisioner: pure-csi
      ---
      # Source: pure-csi/templates/storageclass.yaml
      apiVersion: storage.k8s.io/v1
      kind: StorageClass
      metadata:
        labels:
          chart: pure-csi
          generator: helm
          kubernetes.io/cluster-service: "true"
          release: psoplugin-operator
        name: pure-file
      parameters:
        backend: file
      provisioner: pure-csi
      ---
      # Source: pure-csi/templates/rbac.yaml
      apiVersion: v1
      kind: ServiceAccount
      metadata:
        name: pure
        namespace: pure-csi-operator
        ownerReferences:
        - apiVersion: purestorage.com/v1
          blockOwnerDeletion: true
          controller: true
          kind: PSOPlugin
          name: psoplugin-operator
          uid: f448573f-4af1-4cb6-8532-e5ecb69fe761
      ---
      # Source: pure-csi/templates/rbac.yaml
      apiVersion: rbac.authorization.k8s.io/v1
      kind: ClusterRole
      metadata:
        labels:
          chart: pure-csi
          generator: helm
          release: psoplugin-operator
        name: external-provisioner-runner
      rules:
      - apiGroups:
        - ""
        resources:
        - persistentvolumes
        verbs:
        - get
        - list
        - watch
        - create
        - delete
      - apiGroups:
        - ""
        resources:
        - persistentvolumeclaims
        verbs:
        - get
        - list
        - watch
        - update
      - apiGroups:
        - storage.k8s.io
        resources:
        - storageclasses
        verbs:
        - get
        - list
        - watch
      - apiGroups:
        - ""
        resources:
        - events
        verbs:
        - list
        - watch
        - create
        - update
        - patch
      - apiGroups:
        - snapshot.storage.k8s.io
        resources:
        - volumesnapshots
        verbs:
        - get
        - list
        - watch
        - update
      - apiGroups:
        - snapshot.storage.k8s.io
        resources:
        - volumesnapshots/status
        verbs:
        - update
      - apiGroups:
        - snapshot.storage.k8s.io
        resources:
        - volumesnapshotcontents
        verbs:
        - create
        - get
        - list
        - watch
        - update
        - delete
      - apiGroups:
        - storage.k8s.io
        resources:
        - csinodes
        verbs:
        - get
        - list
        - watch
      - apiGroups:
        - ""
        resources:
        - nodes
        verbs:
        - get
        - list
        - watch
      - apiGroups:
        - snapshot.storage.k8s.io
        resources:
        - volumesnapshotclasses
        verbs:
        - get
        - list
        - watch
      - apiGroups:
        - apiextensions.k8s.io
        resources:
        - customresourcedefinitions
        verbs:
        - create
        - list
        - watch
        - delete
        - get
        - update
      ---
      # Source: pure-csi/templates/rbac.yaml
      apiVersion: rbac.authorization.k8s.io/v1
      kind: ClusterRoleBinding
      metadata:
        labels:
          chart: pure-csi
          generator: helm
          release: psoplugin-operator
        name: csi-snapshotter-role
      roleRef:
        apiGroup: rbac.authorization.k8s.io
        kind: ClusterRole
        name: external-provisioner-runner
      subjects:
      - kind: ServiceAccount
        name: pure
        namespace: pure-csi-operator
      ---
      # Source: pure-csi/templates/rbac.yaml
      apiVersion: rbac.authorization.k8s.io/v1
      kind: ClusterRoleBinding
      metadata:
        labels:
          chart: pure-csi
          generator: helm
          release: psoplugin-operator
        name: csi-provisioner-role
      roleRef:
        apiGroup: rbac.authorization.k8s.io
        kind: ClusterRole
        name: external-provisioner-runner
      subjects:
      - kind: ServiceAccount
        name: pure
        namespace: pure-csi-operator
      ---
      # Source: pure-csi/templates/provisioner.yaml
      apiVersion: v1
      kind: Service
      metadata:
        labels:
          app: pure-provisioner
        name: pure-provisioner
        ownerReferences:
        - apiVersion: purestorage.com/v1
          blockOwnerDeletion: true
          controller: true
          kind: PSOPlugin
          name: psoplugin-operator
          uid: f448573f-4af1-4cb6-8532-e5ecb69fe761
      spec:
        ports:
        - name: dummy
          port: 12345
        selector:
          app: pure-provisioner
      ---
      # Source: pure-csi/templates/service.yaml
      apiVersion: v1
      kind: Service
      metadata:
        labels:
          app.kubernetes.io/instance: psoplugin-operator
          app.kubernetes.io/managed-by: Tiller
          app.kubernetes.io/name: pure-csi
          helm.sh/chart: pure-csi-1.0.7
        name: psoplugin-operator-pure-csi
        ownerReferences:
        - apiVersion: purestorage.com/v1
          blockOwnerDeletion: true
          controller: true
          kind: PSOPlugin
          name: psoplugin-operator
          uid: f448573f-4af1-4cb6-8532-e5ecb69fe761
      spec:
        ports:
        - name: dummy
          port: 12345
        selector:
          app.kubernetes.io/instance: psoplugin-operator
          app.kubernetes.io/name: pure-csi
      ---
      # Source: pure-csi/templates/node.yaml
      apiVersion: apps/v1
      kind: DaemonSet
      metadata:
        labels:
          chart: pure-csi
          generator: helm
          release: psoplugin-operator
        name: pure-csi
        namespace: pure-csi-operator
        ownerReferences:
        - apiVersion: purestorage.com/v1
          blockOwnerDeletion: true
          controller: true
          kind: PSOPlugin
          name: psoplugin-operator
          uid: f448573f-4af1-4cb6-8532-e5ecb69fe761
      spec:
        selector:
          matchLabels:
            app: pure-csi
        template:
          metadata:
            labels:
              app: pure-csi
              chart: pure-csi
              generator: helm
              release: psoplugin-operator
          spec:
            containers:
            - args:
              - --csi-address=/csi/csi.sock
              - --kubelet-registration-path=/var/lib/kubelet/plugins/pure-csi/csi.sock
              env:
              - name: KUBE_NODE_NAME
                valueFrom:
                  fieldRef:
                    apiVersion: v1
                    fieldPath: spec.nodeName
              image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
              imagePullPolicy: Always
              lifecycle:
                preStop:
                  exec:
                    command:
                    - /bin/sh
                    - -c
                    - rm -rf /registration/pure-csi /registration/pure-csi-reg.sock
              name: node-driver-registrar
              securityContext:
                privileged: true
              volumeMounts:
              - mountPath: /csi
                name: socket-dir
              - mountPath: /registration
                name: registration-dir
              - mountPath: /csi-data-dir
                name: csi-data-dir
            - command:
              - /csi-server
              - -endpoint=$(CSI_ENDPOINT)
              - -nodeid=$(KUBE_NODE_NAME)
              env:
              - name: CSI_ENDPOINT
                value: unix:///csi/csi.sock
              - name: KUBE_NODE_NAME
                valueFrom:
                  fieldRef:
                    apiVersion: v1
                    fieldPath: spec.nodeName
              - name: PURE_DISCOVERY_CONF
                value: /etc/pure/pure.json
              - name: PURE_FLASHARRAY_SAN_TYPE
                value: ISCSI
              - name: PURE_K8S_NAMESPACE
                value: openshift
              - name: PURE_DEFAULT_BLOCK_FS_TYPE
                value: xfs
              - name: PURE_DEFAULT_BLOCK_FS_OPT
                value: -q
              - name: PURE_DEFAULT_BLOCK_MNT_OPT
                value: discard
              - name: PURE_PREEMPT_RWO_ATTACHMENTS_DEFAULT
                value: "true"
              - name: PURE_ISCSI_ALLOWED_CIDRS
                value: ""
              - name: PURE_ISCSI_LOGIN_TIMEOUT
                value: "20"
              image: purestorage/k8s:5.0.6
              imagePullPolicy: Always
              livenessProbe:
                failureThreshold: 5
                httpGet:
                  path: /healthz
                  port: healthz
                initialDelaySeconds: 10
                periodSeconds: 2
                timeoutSeconds: 3
              name: pure-csi-container
              ports:
              - containerPort: 9898
                name: healthz
                protocol: TCP
              securityContext:
                privileged: true
              volumeMounts:
              - mountPath: /etc/pure
                name: config
                readOnly: true
              - mountPath: /dev
                name: dev
              - mountPath: /csi
                name: socket-dir
              - mountPath: /var/lib/kubelet/pods
                mountPropagation: Bidirectional
                name: mountpoint-dir
              - mountPath: /var/lib/kubelet/plugins
                mountPropagation: Bidirectional
                name: plugins-dir
              - mountPath: /csi-data-dir
                name: csi-data-dir
            - args:
              - --csi-address=/csi/csi.sock
              - --connection-timeout=3s
              - --health-port=9898
              image: quay.io/k8scsi/livenessprobe:v1.1.0
              imagePullPolicy: Always
              name: liveness-probe
              volumeMounts:
              - mountPath: /csi
                name: socket-dir
            hostNetwork: true
            hostPID: true
            volumes:
            - name: config
              secret:
                secretName: pure-provisioner-secret
            - hostPath:
                path: /dev
              name: dev
            - hostPath:
                path: /var/lib/kubelet/plugins/pure-csi
                type: DirectoryOrCreate
              name: socket-dir
            - hostPath:
                path: /var/lib/kubelet/pods
                type: DirectoryOrCreate
              name: mountpoint-dir
            - hostPath:
                path: /var/lib/kubelet/plugins_registry
                type: Directory
              name: registration-dir
            - hostPath:
                path: /var/lib/kubelet/plugins
                type: Directory
              name: plugins-dir
            - hostPath:
                path: /var/lib/pure-csi-data/
                type: DirectoryOrCreate
              name: csi-data-dir
        updateStrategy:
          rollingUpdate:
            maxUnavailable: 100%
          type: RollingUpdate
      ---
      # Source: pure-csi/templates/provisioner.yaml
      apiVersion: apps/v1
      kind: StatefulSet
      metadata:
        labels:
          chart: pure-csi
          generator: helm
          release: psoplugin-operator
        name: pure-provisioner
        namespace: pure-csi-operator
        ownerReferences:
        - apiVersion: purestorage.com/v1
          blockOwnerDeletion: true
          controller: true
          kind: PSOPlugin
          name: psoplugin-operator
          uid: f448573f-4af1-4cb6-8532-e5ecb69fe761
      spec:
        replicas: 1
        selector:
          matchLabels:
            app: pure-provisioner
        serviceName: pure-provisioner
        template:
          metadata:
            labels:
              app: pure-provisioner
              chart: pure-csi
              generator: helm
              release: psoplugin-operator
          spec:
            containers:
            - command:
              - /csi-server
              - -endpoint=$(CSI_ENDPOINT)
              - -nodeid=$(KUBE_NODE_NAME)
              env:
              - name: CSI_ENDPOINT
                value: unix:///csi/csi.sock
              - name: PURE_DISCOVERY_CONF
                value: /etc/pure/pure.json
              - name: PURE_K8S_NAMESPACE
                value: openshift
              - name: PURE_DEFAULT_BLOCK_FS_TYPE
                value: xfs
              - name: PURE_DEFAULT_ENABLE_FB_NFS_SNAPSHOT
                value: "false"
              image: purestorage/k8s:5.0.6
              imagePullPolicy: Always
              name: pure-csi-container
              volumeMounts:
              - mountPath: /csi
                name: socket-dir
              - mountPath: /etc/pure
                name: config
                readOnly: true
            - args:
              - --csi-address=/csi/csi.sock
              - --connection-timeout=15s
              image: quay.io/k8scsi/csi-provisioner:v1.4.0
              imagePullPolicy: Always
              name: csi-provisioner
              volumeMounts:
              - mountPath: /csi
                name: socket-dir
            - args:
              - --csi-address=/csi/csi.sock
              - --connection-timeout=15s
              - --leader-election=false
              image: quay.io/k8scsi/csi-snapshotter:v1.2.2
              imagePullPolicy: Always
              name: csi-snapshotter
              volumeMounts:
              - mountPath: /csi
                name: socket-dir
            serviceAccountName: pure
            volumes:
            - emptyDir: {}
              name: socket-dir
            - name: config
              secret:
                secretName: pure-provisioner-secret
      ---
      # Source: pure-csi/templates/node.yaml
      apiVersion: storage.k8s.io/v1beta1
      kind: CSIDriver
      metadata:
        name: pure-csi
      spec:
        attachRequired: false
    name: psoplugin-operator
```