### PR TITLE
Update documentation to only support Helm 3 going forward

### DIFF
--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -11,8 +11,8 @@ This helm chart installs the CSI plugin on a Kubernetes cluster.
   - Ubuntu 18.04
 - #### Environments Supported*:
   - Kubernetes 1.13+
-  - Minimum Helm version required is 2.9.1.
-  - OpenShift 3.11
+  - Minimum Helm version required is 3.0.0.
+  - OpenShift 3.11, 4.2, 4.3
   - Google Anthos 1.2.x
 - #### Other software dependencies:
   - Latest linux multipath software package for your operating system (Required)
@@ -55,9 +55,6 @@ Add the Pure Storage helm repo
 ```bash
 helm repo add pure https://purestorage.github.io/helm-charts
 helm repo update
-# Helm 2
-helm search pure-csi
-# Helm 3
 helm search repo pure-csi
 ```
 
@@ -151,9 +148,6 @@ Customize your values.yaml including arrays info (replacement for pure.json), an
 Dry run the installation, and make sure your values.yaml is working correctly.
 
 ```bash
-# Helm 2
-helm install --name pure-storage-driver pure/pure-csi --namespace <namespace> -f <your_own_dir>/yourvalues.yaml --dry-run --debug
-# Helm 3
 helm install pure-storage-driver pure/pure-csi --namespace <namespace> -f <your_own_dir>/yourvalues.yaml --dry-run --debug
 ```
 
@@ -161,9 +155,6 @@ Run the Install
 
 ```bash
 # Install the plugin
-# Helm 2
-helm install --name pure-storage-driver pure/pure-csi --namespace <namespace> -f <your_own_dir>/yourvalues.yaml
-# Helm 3
 helm install pure-storage-driver pure/pure-csi --namespace <namespace> -f <your_own_dir>/yourvalues.yaml
 ```
 
@@ -171,11 +162,6 @@ The values in your values.yaml overwrite the ones in pure-csi/values.yaml, but a
 option will take precedence.
 
 ```bash
-# Helm 2
-helm install --name pure-storage-driver pure/pure-csi --namespace <namespace> -f <your_own_dir>/yourvalues.yaml \
-            --set flasharray.sanType=fc \
-            --set namespace.pure=k8s_xxx \
-# Helm 3
 helm install pure-storage-driver pure/pure-csi --namespace <namespace> -f <your_own_dir>/yourvalues.yaml \
             --set flasharray.sanType=fc \
             --set namespace.pure=k8s_xxx \
@@ -224,9 +210,6 @@ the helm repository with the tag version required. This ensures the supporting c
 ```bash
 # list the avaiable version of the plugin
 helm repo update
-# Helm 2
-helm search pure-csi -l
-# Helm 3
 helm search repo pure-csi -l
 
 # select a target chart version to upgrade as

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -12,7 +12,7 @@ This helm chart installs the CSI plugin on a Kubernetes cluster.
 - #### Environments Supported*:
   - Kubernetes 1.13+
   - Minimum Helm version required is 3.0.3.
-  - OpenShift 3.11, 4.2, 4.3
+  - OpenShift 3.11
   - Google Anthos 1.2.x
 - #### Other software dependencies:
   - Latest linux multipath software package for your operating system (Required)

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -11,7 +11,7 @@ This helm chart installs the CSI plugin on a Kubernetes cluster.
   - Ubuntu 18.04
 - #### Environments Supported*:
   - Kubernetes 1.13+
-  - Minimum Helm version required is 3.0.0.
+  - Minimum Helm version required is 3.0.3.
   - OpenShift 3.11, 4.2, 4.3
   - Google Anthos 1.2.x
 - #### Other software dependencies:

--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -12,7 +12,7 @@ This helm chart installs the FlexVolume plugin on a Kubernetes cluster.
   - For Platform specific requirements see
 - #### Environments Supported*:
   - Kubernetes 1.6+
-  - Minimum Helm version required is 2.9.1
+  - Minimum Helm version required is 3.0.0
   - [OpenShift](#openshift) 3.6+
   - AWS EKS 1.14
 - #### Other software dependencies:
@@ -124,9 +124,6 @@ Customize your values.yaml including arrays info (replacement for pure.json), an
 
 Dry run the installation, and make sure your values.yaml is working correctly:
 ```bash
-# Helm 2
-helm install --name pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml --dry-run --debug
-# Helm 3
 helm install pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml --dry-run --debug
 ```
 
@@ -139,21 +136,12 @@ helm install pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f
 oc adm policy add-scc-to-user privileged system:serviceaccount:<project>:<clusterrolebinding.serviceAccount.name>
 
 # Install the plugin (works for both openshift and kubernetes)
-# Helm 2
-helm install --name pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml
-# Helm 3
 helm install pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml
 ```
 
 The values in your `values.yaml` overwrite the ones in `pure-k8s-plugin/values.yaml`, but any specified with the `--set`
 option will take precedence.
 ```bash
-# Helm 2
-helm install --name pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml \
-            --set flasharray.sanType=fc \
-            --set namespace.pure=k8s_xxx \
-            --set orchestrator.name=openshift
-# Helm 3
 helm install pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml \
             --set flasharray.sanType=fc \
             --set namespace.pure=k8s_xxx \
@@ -186,9 +174,6 @@ the helm repository with the tag version required. This ensures the supporting c
 ```bash
 # list the avaiable version of the plugin
 helm repo update
-# Helm 2
-helm search pure-k8s-plugin -l
-# Helm 3
 helm search repo pure-k8s-plugin -l
 
 # select a target chart version to upgrade as

--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -12,7 +12,7 @@ This helm chart installs the FlexVolume plugin on a Kubernetes cluster.
   - For Platform specific requirements see
 - #### Environments Supported*:
   - Kubernetes 1.6+
-  - Minimum Helm version required is 3.0.0
+  - Minimum Helm version required is 3.0.3
   - [OpenShift](#openshift) 3.6+
   - AWS EKS 1.14
 - #### Other software dependencies:


### PR DESCRIPTION
With the move to Helm 3 and the breaking change that was added to our CRDs with Helm 3 we are going to deprecate support for Helm 2.
This PR will change the documentation to remove references to Helm 2