### PR TITLE
[NSTK-1614] Point to snapshotclass.yaml absolute path 

### DIFF
--- a/operator-csi-plugin/install.sh
+++ b/operator-csi-plugin/install.sh
@@ -478,5 +478,5 @@ done
 if [ $counter -gt $TIMEOUT ]; then
     echo "VolumeSnapshotClasss CRD not found!"
 else
-    $KUBECTL apply -f ../pure-csi/snapshotclass.yaml
+    $KUBECTL apply -f https://raw.githubusercontent.com/purestorage/helm-charts/master/pure-csi/snapshotclass.yaml
 fi


### PR DESCRIPTION
since CI test only copy scripts to host not whole helm-charts repo, we need the absolute path to apply the snapshot class