### PR TITLE
Fix v1beta1 API version for the PSOPlugin CRD

### DIFF
--- a/operator-csi-plugin/install.sh
+++ b/operator-csi-plugin/install.sh
@@ -105,34 +105,8 @@ fi
 # 2. Create CRD and wait until TIMEOUT seconds for the CRD to be established.
 counter=0
 TIMEOUT=10
-
-if [[ ${CRDAPIVERSION} == "apiextensions.k8s.io/v1" ]]; then
-    echo "
-apiVersion: ${CRDAPIVERSION}
-kind: CustomResourceDefinition
-metadata:
-  name: psoplugins.purestorage.com
-spec:
-  group: purestorage.com
-  names:
-    kind: PSOPlugin
-    listKind: PSOPluginList
-    plural: psoplugins
-    singular: psoplugin
-  scope: Namespaced
-  versions:
-  - name: v1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object " | ${KUBECTL} apply -f -
-elif [[ ${CRDAPIVERSION} == "apiextensions.k8s.io/v1beta1" ]]; then
-    echo "
-apiVersion: ${CRDAPIVERSION}
+echo "
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: psoplugins.purestorage.com
@@ -150,10 +124,6 @@ spec:
     storage: true
   subresources:
     status: {} " | ${KUBECTL} apply -f -
-else
-    echo "Cluster does not support CustomResourceDefinitions versions apiextensions.k8s.io/v1beta1 or apiextensions.k8s.io/v1, stopping..."
-    exit 1
-fi
 
 while true; do
     result=$(${KUBECTL} get crd/psoplugins.purestorage.com -o jsonpath='{.status.conditions[?(.type == "Established")].status}{"\n"}' | grep -i true)

--- a/operator-k8s-plugin/install.sh
+++ b/operator-k8s-plugin/install.sh
@@ -105,34 +105,8 @@ fi
 # 2. Create CRD and wait until TIMEOUT seconds for the CRD to be established.
 counter=0
 TIMEOUT=10
-
-if [[ ${CRDAPIVERSION} == "apiextensions.k8s.io/v1" ]]; then
-    echo "
-apiVersion: ${CRDAPIVERSION}
-kind: CustomResourceDefinition
-metadata:
-  name: psoplugins.purestorage.com
-spec:
-  group: purestorage.com
-  names:
-    kind: PSOPlugin
-    listKind: PSOPluginList
-    plural: psoplugins
-    singular: psoplugin
-  scope: Namespaced
-  versions:
-  - name: v1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          spec:
-            type: object " | ${KUBECTL} apply -f -
-elif [[ ${CRDAPIVERSION} == "apiextensions.k8s.io/v1beta1" ]]; then
-    echo "
-apiVersion: ${CRDAPIVERSION}
+echo "
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: psoplugins.purestorage.com
@@ -150,10 +124,6 @@ spec:
     storage: true
   subresources:
     status: {} " | ${KUBECTL} apply -f -
-else
-    echo "Cluster does not support CustomResourceDefinitions versions apiextensions.k8s.io/v1beta1 or apiextensions.k8s.io/v1, stopping..."
-    exit 1
-fi
 
 while true; do
     result=$(${KUBECTL} get crd/psoplugins.purestorage.com -o jsonpath='{.status.conditions[?(.type == "Established")].status}{"\n"}' | grep -i true)


### PR DESCRIPTION
The current operator installation breaks our pso driver.  This is because the `install.sh` script fails to generate the correct PSOPlugin object when using `apiextensions.k8s.io/v1` CRD API to create the `PSOPlugin CRD`. This fix rolls back to use ` apiextensions.k8s.io/v1beta1`.  

I've tested this PR using CI's functional tests on k8s 1.15 and 1.17 version. Both are tested fine.
Note that `apiextensions.k8s.io/v1beta1` is going to depreciate in 1.19 release.  For the future 1.19 release, we need to add `openAPIV3Schema` for strong typing validation of our parameters in the `values.yaml` file.


