### PR TITLE
Update Documentation - Helm2/3 changes and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pure Service Orchestrator (PSO) Helm Charts
 
 ## What is PSO?
+
 Pure Service Orchestrator (PSO) delivers storage-as-a-service for containers, giving developers the agility of public cloud with the reliability and security of on-premises infrastructure.
 
 **Smart Provisioning**<br/>
@@ -13,6 +14,7 @@ Uniting all your Pure FlashArray™ and FlashBlade™ arrays on a single shared 
 To ensure your services stay robust, PSO self-heals – so you’re protected against data corruption caused by issues such as node failure, array performance limits, and low disk space.
 
 ## Software Pre-Requisites
+
 - #### Operating Systems Supported*:
   - CentOS 7
   - CoreOS (Ladybug 1298.6.0 and above)
@@ -33,44 +35,36 @@ To ensure your services stay robust, PSO self-heals – so you’re protected ag
 _* Please see release notes for details_
 
 ## Hardware Pre-Requisites
+
 PSO can be used with any of the following hardware appliances and associated minimum version of appliance code:
   * Pure Storage FlashArray (minimum Purity code version 4.8)
   * Pure Storage FlashBlade (minimum Purity version 2.2.0)
 
 ## Installation
+
 PSO can be deployed via an Operator or from the Helm chart.
 
 ### PSO Operator
+
 PSO has Operator-based install available for both its FlexVolume plugin and CSI plugin. This install method does not need Helm installation. 
 The Pure Flex Operator is supported for OpenShift and Kubernetes.
 Pure Flex Operator is now the preferred installation method for FlexVolume on OpenShift version 3.11 and higher.<br/>
 For installation, see the [Flex Operator Documentation](./operator-k8s-plugin/README.md#overview) or the [CSI Operator Documentation](./operator-csi-plugin/README.md#overview)..
 
 ### Helm Chart
+
 **pure-k8s-plugin** deploys PSO FlexVolume plugin on your Kubernetes cluster.</br> 
 **pure-csi** deploys PSO CSI plugin on your Kubernetes cluster. 
 
 #### Helm Setup
+
 Install Helm by following the official documents:
 1. For Kubernetes<br/>
 https://docs.helm.sh/using_helm#install-helm
 
 2. For OpenShift<br/>
-https://blog.openshift.com/getting-started-helm-openshift/<br/>
-**Starting OpenShift 3.11 the preferred installation method is using the PSO Operator. Follow the instructions in the [operator directory](./operator/README.md).**
+**In OpenShift 3.11 the Red Hat preferred installation method is using an Operator. Follow the instructions in the [PSO operator directory](./operator/README.md).**
 
-In order to enable Tiller (the server-side component of Helm) to install any type of service across the entire cluster, it's required to grant Tiller a cluster-admin role.
-
-After the Helm installation, configure the cluster admin role for the service account of Tiller. You will need to determine the correct service account.
-```bash
-# For K8s with example service account "{TILLER_NAMESPACE}:default"
-kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=${TILLER_NAMESPACE}:default
-
-# For Openshift version < 3.11:
-oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:${TILLER_NAMESPACE}:tiller
-```
-
-For more details, please see https://docs.helm.sh/using_helm/
 
 Refer to the [k8s-plugin README](./pure-k8s-plugin/README.md) or the [csi-plugin README](./pure-csi/README.md) for further installation steps.
 

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -11,7 +11,7 @@ This helm chart installs the CSI plugin on a Kubernetes cluster.
   - Ubuntu 18.04
 - #### Environments Supported*:
   - Kubernetes 1.13+
-  - Minimum Helm version required is 3.0.3.
+  - Minimum Helm version required is 3.1.0.
   - OpenShift 3.11
   - Google Anthos 1.2.x
 - #### Other software dependencies:
@@ -115,23 +115,15 @@ arrays:
   FlashArrays:
     - MgmtEndPoint: "1.2.3.4"
       APIToken: "a526a4c6-18b0-a8c9-1afa-3499293574bb"
-      Labels:
-        rack: "22"
-        env: "prod"
     - MgmtEndPoint: "1.2.3.5"
       APIToken: "b526a4c6-18b0-a8c9-1afa-3499293574bb"
   FlashBlades:
     - MgmtEndPoint: "1.2.3.6"
       APIToken: "T-c4925090-c9bf-4033-8537-d24ee5669135"
       NfsEndPoint: "1.2.3.7"
-      Labels:
-        rack: "7b"
-        env: "dev"
     - MgmtEndPoint: "1.2.3.8"
       APIToken: "T-d4925090-c9bf-4033-8537-d24ee5669135"
       NfsEndPoint: "1.2.3.9"
-      Labels:
-        rack: "6a"
 ```
 
 ## Assigning Pods to Nodes
@@ -145,6 +137,12 @@ For security reason, it's strongly recommended to install the plugin in a separa
 
 Customize your values.yaml including arrays info (replacement for pure.json), and then install with your values.yaml.
 
+Create a namespace for PSO to install into
+
+```bash
+kubectl createnamespace <namespace>
+```
+
 Dry run the installation, and make sure your values.yaml is working correctly.
 
 ```bash
@@ -154,7 +152,6 @@ helm install pure-storage-driver pure/pure-csi --namespace <namespace> -f <your_
 Run the Install
 
 ```bash
-# Install the plugin
 helm install pure-storage-driver pure/pure-csi --namespace <namespace> -f <your_own_dir>/yourvalues.yaml
 ```
 

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -140,7 +140,7 @@ Customize your values.yaml including arrays info (replacement for pure.json), an
 Create a namespace for PSO to install into
 
 ```bash
-kubectl createnamespace <namespace>
+kubectl create namespace <namespace>
 ```
 
 Dry run the installation, and make sure your values.yaml is working correctly.

--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -9,11 +9,10 @@ This helm chart installs the FlexVolume plugin on a Kubernetes cluster.
   - CoreOS (Ladybug 1298.6.0 and above)
   - Ubuntu 16.04
   - Ubuntu 18.04
-  - For Platform specific requirements see
 - #### Environments Supported*:
   - Kubernetes 1.6+
-  - Minimum Helm version required is 3.0.3
-  - [OpenShift](#openshift) 3.6+
+  - Helm 2.9.1+ (**NOTE:** Helm3 is not supported for FlexDriver)
+  - [OpenShift](#openshift) 3.11
   - AWS EKS 1.14
 - #### Other software dependencies:
   - Latest linux multipath software package for your operating system (Required)
@@ -29,16 +28,15 @@ _* Please see release notes for details_
 ## How to install
 
 Add the Pure Storage helm repo
+
 ```bash
 helm repo add pure https://purestorage.github.io/helm-charts
 helm repo update
-# Helm 2
-helm search pure-k8s-plugin
-# Helm 3
 helm search repo pure-k8s-plugin
 ```
 
 Optional (offline installation): Download the helm chart
+
 ```bash
 git clone https://github.com/purestorage/helm-charts.git
 ```
@@ -118,18 +116,21 @@ set but `provisioner.nodeSelector` is not, provisioner will use the value of
 compatible.
 
 ## Install the plugin in a separate namespace (i.e. project)
+
 For security reason, it's strongly recommended to install the plugin in a separate namespace/project. Make sure the namespace is existing, otherwise create it before installing the plugin.
 
 Customize your values.yaml including arrays info (replacement for pure.json), and then install with your values.yaml.
 
 Dry run the installation, and make sure your values.yaml is working correctly:
+
 ```bash
 helm install pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml --dry-run --debug
 ```
 
 **Run the Install:**
+
 ```bash
-# For Openshift only:
+# For Openshift 3.11 only:
 #   you need to add the privileged securityContextConstraints (scc) to the service account which is created for plugin installation.
 #   You can find the serviceaccount info from your values.yaml (if not in it, find in the default values.yaml).
 #   The service account should be "system:serviceaccount:<project>:<clusterrolebinding.serviceAccount.name>"
@@ -139,8 +140,8 @@ oc adm policy add-scc-to-user privileged system:serviceaccount:<project>:<cluste
 helm install pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml
 ```
 
-The values in your `values.yaml` overwrite the ones in `pure-k8s-plugin/values.yaml`, but any specified with the `--set`
-option will take precedence.
+The values in your `values.yaml` overwrite the ones in `pure-k8s-plugin/values.yaml`, but any specified with the `--set` option will take precedence.
+
 ```bash
 helm install pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml \
             --set flasharray.sanType=fc \
@@ -154,6 +155,7 @@ Update your values.yaml with the correct arrays info, and then upgrade the helm 
 
 **Note**: Ensure that the values for `--set` options match when run with the original install step. It is highly recommended
 to use the values.yaml and not specify options with `--set` to make this easier.
+
 ```bash
 helm upgrade pure-storage-driver pure/pure-k8s-plugin --namespace <namespace> -f <your_own_dir>/yourvalues.yaml --set ...
 ```
@@ -171,6 +173,7 @@ More details on using configuration labels can be found [here](../docs/flex-volu
 
 It's not recommended to upgrade by setting the `image.tag` in the image section of values.yaml. Use the version of
 the helm repository with the tag version required. This ensures the supporting changes are present in the templates.
+
 ```bash
 # list the avaiable version of the plugin
 helm repo update
@@ -213,6 +216,7 @@ may be steps required to ensure it can use the FlexVolume plugin. In general
 there are a few requirements that must be met for the plugin to work.
 
 ### Requirements
+
 The container running the kubelet service must have:
 
 * Access to the host systems PID namespace
@@ -242,6 +246,7 @@ Some Kubernetes environments will require special configuration, especially
 on restrictive host operating systems where parts of it are mounted read-only.
 
 ### Atomic
+
 Atomic is configured to have the `/usr` directory tree mounted
 as read-only. This will cause problems installing the `pure-flex` plugin
 as write permission is required.
@@ -257,6 +262,7 @@ Once changed the kublet parameters need to be updated to set the
 via the `flexPath` option in your `values.yaml`.
 
 ### CoreOS
+
 Similar to the Atomic hosts this has a read-only `/usr` tree and requires
 the plugin to be installed to an alternate location. Follow the same
 recommendations to use `/etc/kubernetes/volumeplugins/` and adjust
@@ -264,6 +270,7 @@ the kubelet service to use the `--volume-plugin-dir` CLI argument and
 mount the `/etc/kubernetes` directory into the container.
 
 ### OpenShift
+
 Specify the `orchestrator.name` to be `openshift` and configure the other
 OpenShift specific options.
 
@@ -274,6 +281,7 @@ the right permissions or add the privileged scc to the default service
 account.**
 
 ### OpenShift Containerized Deployment
+
 When deploying OpenShift with the containerized deployment method it is
 going to require mounting the plugin directory through to the container
 running the kubelet service.
@@ -284,10 +292,13 @@ path to use is something like `/etc/origin/kubelet-plugins` or similar
 as the node config path is passed through to the container.
 
 # Release Notes
+
 Release notes can be found [here](https://github.com/purestorage/helm-charts/releases)
 
 ### Known Vulnerabilities 
+
 None
 
 # License
+
 https://www.purestorage.com/content/dam/pdf/en/legal/pure-storage-plugin-end-user-license-agreement.pdf


### PR DESCRIPTION
Some **MAJOR** support statement changes here...

* Only OpenShift 3.11 is supported given Red Hat finished support for 3.10 and older in Oct 2019.
* Only Operator install for FlexDriver is supported in OpenShift 3.11, given Helm2 has moved into maintenance mode and will be deprecated later in the year,
* FlexDriver install is not supported with Helm3
* Add requirement to create a namespace for PSO before running Helm(3) install
* Remove the `labels:` section from the `arrays:` section of `values.yaml` for the CSI driver. These can be added back in when they are supported by Storage Topology - assuming we do it the same way...

also, some formatting fixes for markdown files