### PR TITLE
Revert Add csi storage topology support

### DIFF
--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -77,7 +77,6 @@ The following table lists the configurable parameters and their default values.
 | `image.tag`                 | The image tag to pull              | `5.0.8`                                   |
 | `image.pullPolicy`          | Image pull policy                  | `Always      `                            |
 | `app.debug`                 | Enable/disable debug mode for app  | `false`                                   |
-| `storagetopology.enable`    | Enable/disable csi topology feature  | `false`                                 |
 | `storageclass.isPureDefault`| Set `pure` storageclass to the default | `false`                               |
 | `storageclass.pureBackend`  | Set `pure` storageclass' default backend type | `block`                               |
 | `clusterrolebinding.serviceAccount.name`| Name of K8s/openshift service account for installing the plugin | `pure`                    |

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -78,8 +78,6 @@ The following table lists the configurable parameters and their default values.
 | `image.pullPolicy`          | Image pull policy                  | `Always      `                            |
 | `app.debug`                 | Enable/disable debug mode for app  | `false`                                   |
 | `storagetopology.enable`    | Enable/disable csi topology feature  | `false`                                 |
-| `storagetopology.strictTopology`    | Enable/disable csi [strict topology](https://github.com/kubernetes-csi/external-provisioner/blob/master/README.md#topology-support) feature  | `false`                                 |
-
 | `storageclass.isPureDefault`| Set `pure` storageclass to the default | `false`                               |
 | `storageclass.pureBackend`  | Set `pure` storageclass' default backend type | `block`                               |
 | `clusterrolebinding.serviceAccount.name`| Name of K8s/openshift service account for installing the plugin | `pure`                    |

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -75,9 +75,8 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=15s
-            - --feature-gates=Topology={{ .Values.storagetopology.enable }}
-{{- if and .Values.storagetopology.strictTopology .Values.storagetopology.enable}}
-            - --strict-topology
+{{- if eq .Values.storagetopology.enable true}}
+            - --feature-gates=Topology=true
 {{- end}}
           volumeMounts:
             - name: socket-dir

--- a/pure-csi/templates/provisioner.yaml
+++ b/pure-csi/templates/provisioner.yaml
@@ -75,9 +75,6 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=15s
-{{- if eq .Values.storagetopology.enable true}}
-            - --feature-gates=Topology=true
-{{- end}}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/pure-csi/templates/rbac.yaml
+++ b/pure-csi/templates/rbac.yaml
@@ -96,30 +96,6 @@ roleRef:
   name: external-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
 ---
-kind: ClusterRole
-apiVersion: {{ template "rbac.apiVersion" . }}
-metadata:
-  namespace: {{ .Release.Namespace }}
-  name: pure-topology
-rules:
-  - apiGroups: [""]
-    resources: ["pods", "nodes"]
-    verbs: ["get", "watch", "list"]
-
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: pure-topology
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: pure-topology
-  apiGroup: rbac.authorization.k8s.io
----
 
 {{ if and (eq .Capabilities.KubeVersion.Major "1") (eq .Capabilities.KubeVersion.Minor "13") }}
 # This file is downloaded from https://github.com/kubernetes-csi/cluster-driver-registrar/archive/v1.0.1.tar.gz 

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -29,10 +29,6 @@ csi:
       name: quay.io/k8scsi/livenessprobe
       pullPolicy: Always
 
-# this option is to enable/disable the csi topology feature
-# for pure-csi-driver
-storagetopology:
-  enable: false
 
 # this option is to enable/disable the debug mode of this app
 # for pure-csi-driver

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -33,8 +33,6 @@ csi:
 # for pure-csi-driver
 storagetopology:
   enable: false
-  strictTopology: false
-
 
 # this option is to enable/disable the debug mode of this app
 # for pure-csi-driver


### PR DESCRIPTION
**Summary of changes:**
Although helm install tests are OK, we need to revert these changes because it breaks the master CSI-operator tests. It looks like the RBAC permissions in the `install.sh` script needs to update as well. 

Revert it for now to unblock the master pipeline test.
 