### PR TITLE
Added Read-Write-Many docs

### DIFF
--- a/docs/csi-read-write-many.md
+++ b/docs/csi-read-write-many.md
@@ -1,0 +1,61 @@
+
+# Using Read-Write-Many (RWX) volumes with Kubernetes
+
+## Introduction
+
+The Pure Service Orchestrator Kubernetes CSI driver includes support for Read-Write-Many (RWX) block volumes on FlashArray
+starting with version 5.1.0. This feature allows Kubernetes end-users to create persistent block volumes that may be mounted into
+multiple pods simultaneously. Persistent volume claims created this way can be mounted exactly the same as a normal pod, only
+requiring that `accessModes` contains `ReadWriteMany`.
+
+## Restrictions
+Read-Write-Many cannot be used with all combinations of storage classes. Specifically, we prohibit mounting a block volume
+as a filesystem as RWX.
+
+| Backend Type | Mount Type | Access Mode | Valid? |
+|--------------|------------|-------------|--------|
+| Block        | Block      | RWO         | Yes    |
+| Block        | Block      | RWX         | Yes    |
+| Block        | File       | RWO         | Yes    |
+| Block        | File       | RWX         | **No** |
+| File         | File       | RWO         | Yes    |
+| File         | File       | RWX         | Yes    |
+
+## Examples
+To use these examples, install the Pure CSI plugin and apply the following example files.
+
+### For FlashArray/Cloud Block Store
+
+FlashArrays can only be used for RWX volumes with [raw block mounts](https://kubernetes.io/blog/2019/03/07/raw-block-volume-support-to-beta/), as shown in the following example files.
+
+[Raw Block PVC](examples/rwx/pvc-block-many.yaml)
+
+[Example Pods](examples/rwx/pod-block-many.yaml)
+
+To apply:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/purestorage/helm-charts/master/docs/examples/rwx/pvc-block-many.yaml
+kubectl apply -f https://raw.githubusercontent.com/purestorage/helm-charts/master/docs/examples/rwx/pod-block-many.yaml
+# The raw block device will be mounted at /dev/pure-block-device
+```
+
+**A note on caching:** while testing using the above examples, it can be remarkably annoying to test writing data between
+pods, as it can be difficult to ensure the caches are flushed. One easy way to test the shared block storage is 
+`dd if=/dev/urandom of=/dev/pure-block-device bs=512 count=1 oflag=direct` (where `oflag=direct` will bypass caches), and
+then read using `dd if=/dev/pure-block-device of=/dev/stdout bs=512 count=1 iflag=direct` (where `iflag=direct` will bypass
+caches again).
+
+### For FlashBlade
+
+FlashBlade shares can be easily used for RWX volumes since they use NFS, as shown in the following example files.
+
+[File PVC](examples/rwx/pvc-file-many.yaml)
+
+[Example Pods](examples/rwx/pod-file-many.yaml)
+
+To apply:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/purestorage/helm-charts/master/docs/examples/rwx/pvc-file-many.yaml
+kubectl apply -f https://raw.githubusercontent.com/purestorage/helm-charts/master/docs/examples/rwx/pod-file-many.yaml
+# The NFS volume will be mounted at /data
+```

--- a/docs/examples/rwx/pod-block-many.yaml
+++ b/docs/examples/rwx/pod-block-many.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-raw-block-1
+  labels:
+    app: "nginx-raw-block"
+spec:
+  # Specify a volume that uses the claim defined in pvc.yaml
+  volumes:
+    - name: pure-vol
+      persistentVolumeClaim:
+        claimName: pure-claim-raw-block
+  containers:
+    - name: nginx
+      image: nginx
+      # Configure a device mount for the volume we defined above
+      volumeDevices:
+        - name: pure-vol
+          devicePath: /dev/pure-block-device
+      ports:
+        - containerPort: 80
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - "nginx-raw-block"
+          topologyKey: "kubernetes.io/hostname"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-raw-block-2
+  labels:
+    app: "nginx-raw-block"
+spec:
+  # Specify a volume that uses the claim defined in pvc.yaml
+  volumes:
+    - name: pure-vol
+      persistentVolumeClaim:
+        claimName: pure-claim-raw-block
+  containers:
+    - name: nginx
+      image: nginx
+      # Configure a device mount for the volume we defined above
+      volumeDevices:
+        - name: pure-vol
+          devicePath: /dev/pure-block-device
+      ports:
+        - containerPort: 80
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - "nginx-raw-block"
+          topologyKey: "kubernetes.io/hostname"

--- a/docs/examples/rwx/pod-file-many.yaml
+++ b/docs/examples/rwx/pod-file-many.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-1
+  labels:
+    app: "nginx-file-many"
+spec:
+  # Specify a volume that uses the claim defined in pvc.yaml
+  volumes:
+    - name: pure-vol
+      persistentVolumeClaim:
+        claimName: pure-claim
+  containers:
+    - name: nginx
+      image: nginx
+      # Configure a mount for the volume We define above
+      volumeMounts:
+        - name: pure-vol
+          mountPath: /data
+      ports:
+        - containerPort: 80
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - "nginx-file-many"
+          topologyKey: "kubernetes.io/hostname"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-2
+  labels:
+    app: "nginx-file-many"
+spec:
+  # Specify a volume that uses the claim defined in pvc.yaml
+  volumes:
+    - name: pure-vol
+      persistentVolumeClaim:
+        claimName: pure-claim
+  containers:
+    - name: nginx
+      image: nginx
+      # Configure a mount for the volume We define above
+      volumeMounts:
+        - name: pure-vol
+          mountPath: /data
+      ports:
+        - containerPort: 80
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - "nginx-file-many"
+          topologyKey: "kubernetes.io/hostname"

--- a/docs/examples/rwx/pvc-block-many.yaml
+++ b/docs/examples/rwx/pvc-block-many.yaml
@@ -1,0 +1,15 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  # Referenced in pod.yaml for the volume spec
+  name: pure-claim-raw-block
+spec:
+  # This specifically is what allows the PVC to be used as a raw block device
+  volumeMode: Block
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  # Matches the name defined in deployment/storageclass.yaml
+  storageClassName: pure-block

--- a/docs/examples/rwx/pvc-file-many.yaml
+++ b/docs/examples/rwx/pvc-file-many.yaml
@@ -1,0 +1,13 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  # Referenced in pod.yaml for the volume spec
+  name: pure-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  # Matches the name defined in deployment/storageclass.yaml
+  storageClassName: pure-file

--- a/operator-csi-plugin/README.md
+++ b/operator-csi-plugin/README.md
@@ -53,6 +53,10 @@ More details on using the snapshot and clone functionality can be found [here](.
 
 More details on using customized filesystem options can be found [here](../docs/csi-filesystem-options.md).
 
+## Using Read-Write-Many (RWX) volumes with Kubernetes
+
+More details on using Read-Write-Many (RWX) volumes with Kubernetes can be found [here](../docs/csi-read-write-many.md)
+
 ## PSO use of StorageClass
 
 Whilst there are some default `StorageClass` definitions provided by the PSO installation, refer [here](../docs/custom-storageclasses.md) for more details on these default storage classes and how to create your own cu

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -45,6 +45,10 @@ More details on using the snapshot and clone functionality can be found [here](.
 
 More details on using customized filesystem options can be found [here](../docs/csi-filesystem-options.md).
 
+## Using Read-Write-Many (RWX) volumes with Kubernetes
+
+More details on using Read-Write-Many (RWX) volumes with Kubernetes can be found [here](../docs/csi-read-write-many.md)
+
 ## PSO use of StorageClass
 
 Whilst there are some default `StorageClass` definitions provided by the PSO installation, refer [here](../docs/custom-storageclasses.md) for more details on these default storage classes and how to create your own custom storage classes that can be used by PSO.


### PR DESCRIPTION
Adds a documentation page for RWX volumes. Also starts the convention of having an examples directory in the docs page, for easier usage of demo files.