### PR TITLE
Spellcheck: Delay Binding StorageClass

### DIFF
--- a/docs/csi-topology.md
+++ b/docs/csi-topology.md
@@ -132,7 +132,7 @@ spec:
 ```
 To apply:
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/purestorage/helm-charts/master/docs/examples/topology/pvc-delay-binding.ymal
+kubectl apply -f https://raw.githubusercontent.com/purestorage/helm-charts/master/docs/examples/topology/pvc-delay-binding.yaml
 ```
 Once you apply the delay-binding PVC yaml, you should see the PVC is in pending state and wait for the scheduler for further signal.
 ```


### PR DESCRIPTION
Issue:
* Command for applying sample Delay Binding StorageClass returns a 404 Not Found error

Cause: 
* `.ymal` instead of `.yaml`

Proposed Fix:
* Change to `.yaml` in docs, to match filename