### PR TITLE
Updated volume import docs with backend parameters

### DIFF
--- a/docs/csi-volume-import.md
+++ b/docs/csi-volume-import.md
@@ -50,6 +50,8 @@ spec:
     # TODO: change to the volume name in backend.
     # Volume with any name that exists in backend can be imported, and will not be renamed.
     volumeHandle: ttt-pvc-a90d7d5f-da6c-44db-a306-a4cc122f9dd3
+    volumeAttributes:
+      backend: file
   # TODO: configure your desired reclaim policy,
   # Use Retain if you don't want your volume to get deleted when the PV is deleted.
   persistentVolumeReclaimPolicy: Delete

--- a/docs/examples/volumeimport/pv-import-block.yaml
+++ b/docs/examples/volumeimport/pv-import-block.yaml
@@ -22,6 +22,8 @@ spec:
     # TODO: change to the volume name in backend.
     # Volume with any name that exists in backend can be imported, and will not be renamed.
     volumeHandle: ns03276-pvc-2031faf1-8348-4ac8-9737-1a0a9989cad7
+    volumeAttributes:
+      backend: block
   # TODO: configure your desired reclaim policy,
   # Use Retain if you don't want your volume to get deleted when the PV is deleted.
   persistentVolumeReclaimPolicy: Delete

--- a/docs/examples/volumeimport/pv-import-file.yaml
+++ b/docs/examples/volumeimport/pv-import-file.yaml
@@ -22,6 +22,8 @@ spec:
     # TODO: change to the volume name in backend.
     # Volume with any name that exists in backend can be imported, and will not be renamed.
     volumeHandle: ttt-pvc-a90d7d5f-da6c-44db-a306-a4cc122f9dd3
+    volumeAttributes:
+      backend: file
   # TODO: configure your desired reclaim policy,
   # Use Retain if you don't want your volume to get deleted when the PV is deleted.
   persistentVolumeReclaimPolicy: Delete

--- a/docs/examples/volumeimport/pv-import-raw.yaml
+++ b/docs/examples/volumeimport/pv-import-raw.yaml
@@ -22,6 +22,8 @@ spec:
     # TODO: change to the volume name in backend.
     # Volume with any name that exists in backend can be imported, and will not be renamed.
     volumeHandle: ns04132-pvc-540d6142-2e86-45ba-939d-c0be5d8fd335
+    volumeAttributes:
+      backend: block
   # TODO: configure your desired reclaim policy,
   # Use Retain if you don't want your volume to get deleted when the PV is deleted.
   persistentVolumeReclaimPolicy: Delete


### PR DESCRIPTION
For very specific cases involving ReadWriteMany (RWX) access modes on imported volumes, certain parameters are missing from the CSI requests. This fixes that issue by manually providing the important parameter (`backend`).