### PR TITLE
Enabled plugin to work on OSE 4.4

### DIFF
--- a/pure-csi/templates/scc.yaml
+++ b/pure-csi/templates/scc.yaml
@@ -1,0 +1,34 @@
+{{- if eq .Values.orchestrator.name "openshift"}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: pso-scc
+
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.clusterrolebinding.serviceAccount.name }}
+volumes:
+  # Allow all volume types (we specifically use hostPath and secrets)
+  - '*'
+{{- end}}

--- a/pure-csi/values.schema.json
+++ b/pure-csi/values.schema.json
@@ -1258,6 +1258,7 @@
                 "name": {
                     "$id": "#/properties/orchestrator/properties/name",
                     "type": "string",
+                    "enum": ["k8s", "openshift"],
                     "title": "The name schema",
                     "default": "",
                     "examples": [


### PR DESCRIPTION
Adds a required SecurityContextConstraint to allow the node pods to use hostNetwork/hostPID/etc.