### PR TITLE
Added OSE dynamic provisioning docs to Flex READMEs

### DIFF
--- a/operator-k8s-plugin/README.md
+++ b/operator-k8s-plugin/README.md
@@ -23,6 +23,8 @@ This installation process does not require Helm installation.
     - Access to a user account that has cluster-admin privileges.
   - OpenShift 3.11
     - Access to a user account that has cluster-admin privileges.
+    - [Dynamic provisioning](https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/dynamically_provisioning_pvs.html#overview) enabled in the master nodes.
+    - [Controller attach-detach disabled](https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/enabling_controller_attach_detach.html#configuring-nodes-to-enable-controller-managed-attachment-and-detachment) in all nodes the flex driver is running on.
 - #### Other software dependencies:
   - Latest linux multipath software package for your operating system (Required)
   - Latest Filesystem utilities/drivers (XFS by default, Required)

--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -17,6 +17,8 @@ This helm chart installs the FlexVolume plugin on a Kubernetes cluster.
   - Kubernetes 1.6+
   - Helm 2.9.1+ (**NOTE:** Helm3 is not supported for FlexDriver)
   - [OpenShift](#openshift) 3.11
+    - [Dynamic provisioning](https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/dynamically_provisioning_pvs.html#overview) enabled in the master nodes.
+    - [Controller attach-detach disabled](https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/enabling_controller_attach_detach.html#configuring-nodes-to-enable-controller-managed-attachment-and-detachment) in all nodes the flex driver is running on.
   - AWS EKS 1.14
 - #### Other software dependencies:
   - Latest linux multipath software package for your operating system (Required)


### PR DESCRIPTION
Based on the findings from a recent escalation, we confirmed that dynamic provisioning must be enabled in the master nodes, and that controller attach-detach must be disabled on all worker nodes. This updates the docs to reflect this to ease debugging in the future.