### PR TITLE
Add max k8s version

### DIFF
--- a/operator-csi-plugin/README.md
+++ b/operator-csi-plugin/README.md
@@ -13,7 +13,7 @@ This installation process does not require Helm installation.
 ## Platform and Software Dependencies
 
 - #### Environments Supported*:
-  - Red Hat OpenShift 4.3+
+  - Red Hat OpenShift 4.3 - 4.4
 - #### Other software dependencies:
   - Latest linux multipath software package for your operating system (Required)
   - Latest Filesystem utilities/drivers (XFS by default, Required)

--- a/operator-k8s-plugin/README.md
+++ b/operator-k8s-plugin/README.md
@@ -19,7 +19,7 @@ This installation process does not require Helm installation.
   - Ubuntu 16.04
   - Ubuntu 18.04
 - #### Environments Supported*:
-  - Kubernetes 1.11+
+  - Kubernetes 1.11
     - Access to a user account that has cluster-admin privileges.
   - OpenShift 3.11
     - Access to a user account that has cluster-admin privileges.

--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -14,7 +14,7 @@ This helm chart installs the CSI plugin on a Kubernetes cluster.
   - Ubuntu 16.04
   - Ubuntu 18.04
 - #### Environments Supported*:
-  - Kubernetes 1.13+
+  - Kubernetes 1.13 - 1.17
   - Minimum Helm version required is 3.1.0.
   - Google Anthos 1.2.x, 1.3.x, 1.4.x
   - Docker Kuberenetes Service (DKS) - based on Docker EE 3.0 with Kubernetes 1.14.3

--- a/pure-k8s-plugin/README.md
+++ b/pure-k8s-plugin/README.md
@@ -14,7 +14,7 @@ This helm chart installs the FlexVolume plugin on a Kubernetes cluster.
   - Ubuntu 16.04
   - Ubuntu 18.04
 - #### Environments Supported*:
-  - Kubernetes 1.6+
+  - Kubernetes 1.6 - 1.13
   - Helm 2.9.1+ (**NOTE:** Helm3 is not supported for FlexDriver)
   - [OpenShift](#openshift) 3.11
     - [Dynamic provisioning](https://docs.openshift.com/container-platform/3.11/install_config/persistent_storage/dynamically_provisioning_pvs.html#overview) enabled in the master nodes.


### PR DESCRIPTION
A customer requested the max k8s version supported to be added.
Given PSO 5 only supports the Alpha snapshot API we have to limit the max to when this changed to beta, ie 1.17
Also change maximum versions for the old Flex driver plugins as well