### PR TITLE
Make creating the secret optional

### DIFF
--- a/pure-csi/README.md
+++ b/pure-csi/README.md
@@ -102,7 +102,7 @@ The following table lists the configurable parameters and their default values.
 | `namespace.pure`            | Namespace for the backend storage  | `k8s`                                     |
 | `orchestrator.name`         | Orchestrator type, such as openshift, k8s | `k8s`                              |
 | `orchestrator.basePath`     | Base path of the Kubelet, should contain the `plugins`, `plugins_registry`, and `pods` directories. | `/var/lib/kubelet`                              |
-| *`arrays`                    | Array list of all the backend FlashArrays and FlashBlades | must be set by user, see an example below                |
+| *`arrays`                    | Array list of all the backend FlashArrays and FlashBlades | may be set by user, see two examples below                |
 | `mounter.nodeSelector`              | [NodeSelectors](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) Select node-labels to schedule CSI node plugin. | `{}` |
 | `mounter.tolerations`               | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#concepts)  | `[]` |
 | `mounter.affinity`                  | [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) | `{}` |
@@ -122,6 +122,8 @@ The following table lists the configurable parameters and their default values.
 
 *Examples:
 
+1. Helm values  
+To have helm create and manage the secret holding the API tokens use the following in your values file.  
 ```yaml
 arrays:
   FlashArrays:
@@ -136,6 +138,40 @@ arrays:
     - MgmtEndPoint: "1.2.3.8"
       APIToken: "T-d4925090-c9bf-4033-8537-d24ee5669135"
       NfsEndPoint: "1.2.3.9"
+```
+
+2. Manual secret  
+If you wish to manage the secret holding the API tokens yourself do the following;  
+Create a kubernetes secret called `pure-provisioner-secret` with a single key `pure.json` containing json formatted like so  
+```json
+{
+  "FlashArrays": [
+    {
+      "MgmtEndPoint":"1.2.3.4",
+      "APIToken":"a526a4c6-18b0-a8c9-1afa-3499293574bb"
+    },
+    {
+      "MgmtEndPoint":"1.2.3.5",
+      "APIToken":"b526a4c6-18b0-a8c9-1afa-3499293574bb"
+    }
+  ],
+  "FlashBlades": [
+    {
+      "MgmtEndPoint":"1.2.3.6",
+      "APIToken":"T-c4925090-c9bf-4033-8537-d24ee5669135",
+      "NfsEndPoint":"1.2.3.7"
+    },
+    {
+      "MgmtEndPoint":"1.2.3.8",
+      "APIToken":"T-d4925090-c9bf-4033-8537-d24ee5669135",
+      "NfsEndPoint":"1.2.3.9"
+    }
+  ]
+}
+```
+Set the helm value `existingSecret` to true  
+```yaml
+existingSecret: true
 ```
 
 ## Assigning Pods to Nodes

--- a/pure-csi/templates/secret.yaml
+++ b/pure-csi/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 {{ include "pure_csi.labels" . | indent 4}}
 data:
   pure.json: {{ .Values.arrays | toJson | b64enc | quote }}
+{{- end }}

--- a/pure-csi/values.schema.json
+++ b/pure-csi/values.schema.json
@@ -222,31 +222,6 @@
                 }
             ],
 
-
-
-            "oneOf": [  
-                    
-                {
-                    "properties":{
-                        "FlashArrays": {"minItems": 1},
-                        "FlashBlades": {"maxItems": 0}
-                    }
-                },
-                {
-                    "properties":{
-                        "FlashArrays": {"maxItems": 0},
-                        "FlashBlades": {"minItems": 1}
-                    }
-                },    
-                {
-                    "properties":{
-                        "FlashArrays": {"minItems": 1},
-                        "FlashBlades": {"minItems": 1}
-                    }
-                }            
-
-            ],
-
             "additionalProperties": true,
             "properties": {
                 "FlashArrays": {

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -86,6 +86,9 @@ orchestrator:
   # Default is /var/lib/kubelet. For CoreOS and Rancher, this is usually /opt/rke/var/lib/kubelet unless configured otherwise.
   basePath: "/var/lib/kubelet"
 
+# If you wish to manage the secret "pure-provisioner-secret" yourself set this to true.
+existingSecret: false
+
 # arrays specify what storage arrays should be managed by the plugin, this is
 # required to be set upon installation. For FlashArrays you must set the "MgmtEndPoint"
 # and "APIToken", and for FlashBlades you need the additional "NFSEndPoint" parameter.


### PR DESCRIPTION
If I understand https://github.com/purestorage/helm-charts/issues/172 correctly, this might be that.

My aim is to have the flux helm-controller install the chart, and it's impractical to pass the API tokens securely for the chart to create the secret.
A sealed-secret solves the problem of getting the values in but the chart will at best overwrite the unsealed secret.

I am very much open to ideas on how to handle the validation of `arrays` better.