### PR TITLE
Name resizer

### DIFF
--- a/pure-csi/templates/rbac.yaml
+++ b/pure-csi/templates/rbac.yaml
@@ -182,7 +182,7 @@ roleRef:
 kind: ClusterRole
 apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
-  name: external-resizer-runner
+  name: {{ .Values.clusterrole.name }}
   labels:
 {{ include "pure_csi.labels" . | indent 4}}
 rules:
@@ -208,7 +208,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
-  name: csi-resizer-role
+  name: {{ .Values.clusterrolebinding.name }}
   labels:
 {{ include "pure_csi.labels" . | indent 4}}
 subjects:

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -53,10 +53,15 @@ storageclass:
   # set the type of backend you want for the 'pure' storageclass
   pureBackend: "block"
 
-# specify the service account name for this app
+# specify the service account name for this app and the ClusterRoleBinding resizer name
 clusterrolebinding:
+  name: csi-resizer-role
   serviceAccount:
     name: "pure"
+  
+# specify the  ClusterRole name
+clusterrole:
+  name: external-resizer-runner
 
 # support ISCSI or FC, not case sensitive
 flasharray:

--- a/pure-csi/values.yaml
+++ b/pure-csi/values.yaml
@@ -55,13 +55,13 @@ storageclass:
 
 # specify the service account name for this app and the ClusterRoleBinding resizer name
 clusterrolebinding:
-  name: csi-resizer-role
+  name: "csi-resizer-role"
   serviceAccount:
     name: "pure"
   
 # specify the  ClusterRole name
 clusterrole:
-  name: external-resizer-runner
+  name: "external-resizer-runner"
 
 # support ISCSI or FC, not case sensitive
 flasharray:


### PR DESCRIPTION
When trying to add a second CSI driver to my cluster I ran into the issue where both CSI drivers were trying to compete for the csi-resizer-role ClusterRoleBinding and the external-resizer-runner ClusterRole. 

I added the ability to change the names of the ClusterRoleBinding and the ClusterRole. By changing the names of these I was able to install 2 seperate CSI drivers and still maintain the ability to resize volumes.